### PR TITLE
Add bottom bar button with TODO and resource clean-up

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -5,15 +5,20 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.jahi.pipelinetest.ui.theme.PipelineTestTheme
+import com.jahi.pipelinetest.ui.theme.AppDimens
+import com.jahi.pipelinetest.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
@@ -28,6 +33,16 @@ class MainActivity : ComponentActivity() {
                         TopAppBar(
                             title = { Text(text = "Pipeline Test") }
                         )
+                    },
+                    bottomBar = {
+                        Button(
+                            onClick = { /* TODO: Implement action for New Button */ },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(AppDimens.StandardPadding)
+                        ) {
+                            Text(text = stringResource(R.string.new_button_label))
+                        }
                     }
                 ) { innerPadding ->
                     Greeting(

--- a/app/src/main/java/com/jahi/pipelinetest/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/ui/theme/Dimens.kt
@@ -1,0 +1,7 @@
+package com.jahi.pipelinetest.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+object AppDimens {
+    val StandardPadding = 16.dp
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Pipeline test</string>
+    <string name="new_button_label">New Button</string>
 </resources>


### PR DESCRIPTION
## Summary
- add bottom bar button placeholder to `MainActivity`
- extract button label to `strings.xml`
- centralize standard padding in `AppDimens`

## Testing
- `./gradlew assembleDebug --offline`
