### PR TITLE
Improve daily widget display

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
@@ -104,11 +104,10 @@ class DailyCountdownWidget : AppWidgetProvider() {
             val hours = seconds / 3_600
             seconds %= 3_600
             val minutes = seconds / 60
-            seconds %= 60
             return if (days > 0) {
-                String.format("%d days %02d:%02d:%02d", days, hours, minutes, seconds)
+                String.format("%d days %02d:%02d", days, hours, minutes)
             } else {
-                String.format("%02d:%02d:%02d", hours, minutes, seconds)
+                String.format("%02d:%02d", hours, minutes)
             }
         }
     }

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <gradient
+        android:startColor="#4F46E5"
+        android:endColor="#38BDF8"
+        android:angle="135" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/daily_countdown_widget.xml
+++ b/app/src/main/res/layout/daily_countdown_widget.xml
@@ -4,13 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
-    android:background="@android:color/transparent">
+    android:background="@drawable/widget_background">
 
     <TextView
         android:id="@+id/countdown_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textColor="@android:color/white"
-        android:textSize="16sp"
-        android:text="00:00:00" />
+        android:textSize="32sp"
+        android:text="00:00" />
 </FrameLayout>


### PR DESCRIPTION
## Summary
- jazz up `daily_countdown_widget` background with a gradient
- enlarge time text display
- show hours and minutes only in widget countdown

## Testing
- `./gradlew assembleDebug --offline`
