### PR TITLE
Add toggle to countdown cards

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/CountdownScreens.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/CountdownScreens.kt
@@ -3,12 +3,16 @@ package com.jahi.pipelinetest
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -21,18 +25,26 @@ import com.jahi.pipelinetest.ui.theme.Slate400
 import com.jahi.pipelinetest.ui.theme.SurfaceDark
 
 @Composable
-private fun CountdownCard(title: String, value: String) {
+private fun CountdownCard(
+    title: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    var showTitle by remember { mutableStateOf(true) }
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(AppDimens.StandardPadding),
+            .padding(AppDimens.StandardPadding)
+            .clickable { showTitle = !showTitle },
         colors = CardDefaults.cardColors(containerColor = SurfaceDark.copy(alpha = 0.7f))
     ) {
         Column(
             modifier = Modifier.padding(24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(text = title, color = Slate400)
+            if (showTitle) {
+                Text(text = title, color = Slate400)
+            }
             Text(
                 text = value,
                 color = Slate100,
@@ -53,13 +65,15 @@ fun CountdownsScreen(
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         CountdownCard(
             title = "Daily Countdown",
-            value = viewModel.formatTime(viewModel.durationToEndOfDay(now))
+            value = viewModel.formatTime(viewModel.durationToEndOfDay(now)),
+            modifier = Modifier.align(Alignment.CenterHorizontally)
         )
 
         if (viewModel.showYearCountdown) {
             CountdownCard(
                 title = "Year Countdown",
-                value = viewModel.daysUntilEndOfYear(now).toString() + " days"
+                value = viewModel.daysUntilEndOfYear(now).toString() + " days",
+                modifier = Modifier.align(Alignment.CenterHorizontally)
             )
         }
 
@@ -73,7 +87,8 @@ fun CountdownsScreen(
                         viewModel.formatDuration(diff)
                     } else {
                         "${diff.toDays()} days"
-                    }
+                    },
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
             }
         }


### PR DESCRIPTION
## Summary
- center countdown card contents
- allow toggling the label on Daily and Year countdown cards by tapping them

## Testing
- `./gradlew assembleDebug --offline`
