### PR TITLE
Fix settings date picker click

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -128,6 +128,7 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                                 value = event.date,
                                 onValueChange = {},
                                 readOnly = true,
+                                enabled = false,
                                 label = { Text("Event Date") },
                                 modifier = Modifier.fillMaxWidth()
                             )


### PR DESCRIPTION
## Summary
- wrap the Event Date `TextField` with a clickable `Box` so the date picker dialog shows

## Testing
- `./gradlew assembleDebug --offline`
