### PR TITLE
Fix settings date picker click

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -111,11 +111,7 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                             modifier = Modifier.fillMaxWidth()
                         )
                         val context = LocalContext.current
-                        TextField(
-                            value = event.date,
-                            onValueChange = {},
-                            readOnly = true,
-                            label = { Text("Event Date") },
+                        androidx.compose.foundation.layout.Box(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
@@ -127,7 +123,16 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                                         events[index] = event.copy(date = selected)
                                     }
                                 }
-                        )
+                        ) {
+                            TextField(
+                                value = event.date,
+                                onValueChange = {},
+                                readOnly = true,
+                                enabled = false,
+                                label = { Text("Event Date") },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
                         RowCheckbox("Show Time", event.showTime) {
                             events[index] = event.copy(showTime = it)
                         }


### PR DESCRIPTION
## Summary
- disable TextField interaction so the parent Box gets the click

## Testing
- `./gradlew assembleDebug --offline`
