### PR TITLE
Add generate button to all widgets

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/CircularProgressWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/CircularProgressWidget.kt
@@ -11,7 +11,13 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
+import android.media.MediaPlayer
 import android.widget.RemoteViews
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.concurrent.thread
+import kotlin.random.Random
 import java.time.Duration
 import java.time.LocalDateTime
 
@@ -47,6 +53,9 @@ class CircularProgressWidget : AppWidgetProvider() {
                 val thisWidget = ComponentName(context, CircularProgressWidget::class.java)
                 val appWidgetIds = appWidgetManager.getAppWidgetIds(thisWidget)
                 onUpdate(context, appWidgetManager, appWidgetIds)
+            }
+            ACTION_GENERATE_AUDIO -> {
+                generateAndPlay(context)
             }
         }
     }
@@ -94,6 +103,13 @@ class CircularProgressWidget : AppWidgetProvider() {
     companion object {
         private const val REQUEST_CODE_UPDATE = 200
         private const val UPDATE_INTERVAL_MILLIS = 60000 // Update every minute
+        const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
+
+        private val motivationalSentences = listOf(
+            "You can achieve anything you set your mind to.",
+            "Believe in yourself and all that you are.",
+            "Every day is a chance to get better."
+        )
 
         internal fun updateAppWidget(
             context: Context,
@@ -140,7 +156,18 @@ class CircularProgressWidget : AppWidgetProvider() {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
             views.setOnClickPendingIntent(R.id.circular_progress_widget_container, pendingIntent)
-            
+
+            val genIntent = Intent(context, CircularProgressWidget::class.java).apply {
+                action = ACTION_GENERATE_AUDIO
+            }
+            val genPending = PendingIntent.getBroadcast(
+                context,
+                1,
+                genIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.generate_button, genPending)
+
             appWidgetManager.updateAppWidget(appWidgetId, views)
         }
         
@@ -194,6 +221,48 @@ class CircularProgressWidget : AppWidgetProvider() {
             }
             
             return bitmap
+        }
+
+        private fun generateAndPlay(context: Context) {
+            thread {
+                val text = motivationalSentences[Random.nextInt(motivationalSentences.size)]
+                val file = fetchAudio(context, text)
+                file?.let { playAudio(it) }
+            }
+        }
+
+        private fun fetchAudio(context: Context, text: String): File? {
+            return try {
+                val url = URL("https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL/stream")
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "POST"
+                conn.setRequestProperty("xi-api-key", BuildConfig.ELEVEN_LAB_KEY)
+                conn.setRequestProperty("Content-Type", "application/json")
+                conn.doOutput = true
+                val body = "{\"text\": \"$text\"}"
+                conn.outputStream.use { it.write(body.toByteArray()) }
+                if (conn.responseCode == HttpURLConnection.HTTP_OK) {
+                    val file = File.createTempFile("tts", ".mp3", context.cacheDir)
+                    conn.inputStream.use { input -> file.outputStream().use { input.copyTo(it) } }
+                    file
+                } else null
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private fun playAudio(file: File) {
+            try {
+                val mp = MediaPlayer()
+                mp.setDataSource(file.absolutePath)
+                mp.setOnCompletionListener {
+                    it.release()
+                    file.delete()
+                }
+                mp.prepare()
+                mp.start()
+            } catch (_: Exception) {
+            }
         }
     }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
@@ -4,10 +4,16 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ComponentName
+import android.media.MediaPlayer
 import android.widget.RemoteViews
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.concurrent.thread
+import kotlin.random.Random
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -47,6 +53,8 @@ class DailyCountdownWidget : AppWidgetProvider() {
                 updateAppWidget(context, manager, id)
             }
             scheduleUpdates(context)
+        } else if (intent.action == ACTION_GENERATE_AUDIO) {
+            generateAndPlay(context)
         }
     }
 
@@ -90,6 +98,14 @@ class DailyCountdownWidget : AppWidgetProvider() {
     }
 
     companion object {
+        const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
+
+        private val motivationalSentences = listOf(
+            "You can achieve anything you set your mind to.",
+            "Believe in yourself and all that you are.",
+            "Every day is a chance to get better."
+        )
+
         fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
             val views = RemoteViews(context.packageName, R.layout.daily_countdown_widget)
             val remaining = durationToEndOfDay()
@@ -103,6 +119,17 @@ class DailyCountdownWidget : AppWidgetProvider() {
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
             views.setOnClickPendingIntent(R.id.countdown_container, pendingIntent)
+
+            val genIntent = Intent(context, DailyCountdownWidget::class.java).apply {
+                action = ACTION_GENERATE_AUDIO
+            }
+            val genPending = PendingIntent.getBroadcast(
+                context,
+                1,
+                genIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            views.setOnClickPendingIntent(R.id.generate_button, genPending)
 
             appWidgetManager.updateAppWidget(appWidgetId, views)
         }
@@ -125,6 +152,48 @@ class DailyCountdownWidget : AppWidgetProvider() {
                 String.format("%d days %02d:%02d", days, hours, minutes)
             } else {
                 String.format("%02d:%02d", hours, minutes)
+            }
+        }
+
+        private fun generateAndPlay(context: Context) {
+            thread {
+                val text = motivationalSentences[Random.nextInt(motivationalSentences.size)]
+                val file = fetchAudio(context, text)
+                file?.let { playAudio(it) }
+            }
+        }
+
+        private fun fetchAudio(context: Context, text: String): File? {
+            return try {
+                val url = URL("https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL/stream")
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "POST"
+                conn.setRequestProperty("xi-api-key", BuildConfig.ELEVEN_LAB_KEY)
+                conn.setRequestProperty("Content-Type", "application/json")
+                conn.doOutput = true
+                val body = "{\"text\": \"$text\"}"
+                conn.outputStream.use { it.write(body.toByteArray()) }
+                if (conn.responseCode == HttpURLConnection.HTTP_OK) {
+                    val file = File.createTempFile("tts", ".mp3", context.cacheDir)
+                    conn.inputStream.use { input -> file.outputStream().use { input.copyTo(it) } }
+                    file
+                } else null
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        private fun playAudio(file: File) {
+            try {
+                val mp = MediaPlayer()
+                mp.setDataSource(file.absolutePath)
+                mp.setOnCompletionListener {
+                    it.release()
+                    file.delete()
+                }
+                mp.prepare()
+                mp.start()
+            } catch (_: Exception) {
             }
         }
     }

--- a/app/src/main/res/layout/circular_progress_widget.xml
+++ b/app/src/main/res/layout/circular_progress_widget.xml
@@ -27,4 +27,12 @@
         android:shadowDy="1"
         android:shadowRadius="2" />
 
+    <Button
+        android:id="@+id/generate_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_marginTop="8dp"
+        android:text="Generate" />
+
 </FrameLayout>

--- a/app/src/main/res/layout/daily_countdown_widget.xml
+++ b/app/src/main/res/layout/daily_countdown_widget.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/countdown_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center"
     android:padding="16dp"
     android:background="@drawable/widget_background">
 
@@ -10,9 +12,15 @@
         android:id="@+id/countdown_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
         android:gravity="center"
         android:textColor="@android:color/white"
         android:textSize="32sp"
         android:text="00:00" />
-</FrameLayout>
+
+    <Button
+        android:id="@+id/generate_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Generate"
+        android:layout_marginTop="8dp" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add Generate button to `daily_countdown_widget.xml`
- add Generate button to `circular_progress_widget.xml`
- implement audio generation support in `DailyCountdownWidget`
- implement audio generation support in `CircularProgressWidget`

## Testing
- `./gradlew assembleDebug --offline` *(fails: No cached version available for offline mode)*

------
https://chatgpt.com/codex/tasks/task_b_683c4b820b5c832a8fae9a8852e6d157