### PR TITLE
Refactor widgets with MVVM and audio use case

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/CircularProgressWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/CircularProgressWidget.kt
@@ -11,13 +11,9 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
-import android.media.MediaPlayer
 import android.widget.RemoteViews
-import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
-import kotlin.concurrent.thread
-import kotlin.random.Random
+import com.jahi.pipelinetest.domain.GenerateAudioUseCase
+import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import java.time.Duration
 import java.time.LocalDateTime
 
@@ -55,7 +51,8 @@ class CircularProgressWidget : AppWidgetProvider() {
                 onUpdate(context, appWidgetManager, appWidgetIds)
             }
             ACTION_GENERATE_AUDIO -> {
-                generateAndPlay(context)
+                val vm = WidgetViewModel(GenerateAudioUseCase(context))
+                vm.playMotivationalAudio()
             }
         }
     }
@@ -104,12 +101,6 @@ class CircularProgressWidget : AppWidgetProvider() {
         private const val REQUEST_CODE_UPDATE = 200
         private const val UPDATE_INTERVAL_MILLIS = 60000 // Update every minute
         const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
-
-        private val motivationalSentences = listOf(
-            "You can achieve anything you set your mind to.",
-            "Believe in yourself and all that you are.",
-            "Every day is a chance to get better."
-        )
 
         internal fun updateAppWidget(
             context: Context,
@@ -223,46 +214,5 @@ class CircularProgressWidget : AppWidgetProvider() {
             return bitmap
         }
 
-        private fun generateAndPlay(context: Context) {
-            thread {
-                val text = motivationalSentences[Random.nextInt(motivationalSentences.size)]
-                val file = fetchAudio(context, text)
-                file?.let { playAudio(it) }
-            }
-        }
-
-        private fun fetchAudio(context: Context, text: String): File? {
-            return try {
-                val url = URL("https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL/stream")
-                val conn = url.openConnection() as HttpURLConnection
-                conn.requestMethod = "POST"
-                conn.setRequestProperty("xi-api-key", BuildConfig.ELEVEN_LAB_KEY)
-                conn.setRequestProperty("Content-Type", "application/json")
-                conn.doOutput = true
-                val body = "{\"text\": \"$text\"}"
-                conn.outputStream.use { it.write(body.toByteArray()) }
-                if (conn.responseCode == HttpURLConnection.HTTP_OK) {
-                    val file = File.createTempFile("tts", ".mp3", context.cacheDir)
-                    conn.inputStream.use { input -> file.outputStream().use { input.copyTo(it) } }
-                    file
-                } else null
-            } catch (e: Exception) {
-                null
-            }
-        }
-
-        private fun playAudio(file: File) {
-            try {
-                val mp = MediaPlayer()
-                mp.setDataSource(file.absolutePath)
-                mp.setOnCompletionListener {
-                    it.release()
-                    file.delete()
-                }
-                mp.prepare()
-                mp.start()
-            } catch (_: Exception) {
-            }
-        }
     }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
@@ -7,13 +7,9 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.media.MediaPlayer
 import android.widget.RemoteViews
-import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
-import kotlin.concurrent.thread
-import kotlin.random.Random
+import com.jahi.pipelinetest.domain.GenerateAudioUseCase
+import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -54,7 +50,8 @@ class DailyCountdownWidget : AppWidgetProvider() {
             }
             scheduleUpdates(context)
         } else if (intent.action == ACTION_GENERATE_AUDIO) {
-            generateAndPlay(context)
+            val vm = WidgetViewModel(GenerateAudioUseCase(context))
+            vm.playMotivationalAudio()
         }
     }
 
@@ -99,12 +96,6 @@ class DailyCountdownWidget : AppWidgetProvider() {
 
     companion object {
         const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
-
-        private val motivationalSentences = listOf(
-            "You can achieve anything you set your mind to.",
-            "Believe in yourself and all that you are.",
-            "Every day is a chance to get better."
-        )
 
         fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
             val views = RemoteViews(context.packageName, R.layout.daily_countdown_widget)
@@ -155,46 +146,5 @@ class DailyCountdownWidget : AppWidgetProvider() {
             }
         }
 
-        private fun generateAndPlay(context: Context) {
-            thread {
-                val text = motivationalSentences[Random.nextInt(motivationalSentences.size)]
-                val file = fetchAudio(context, text)
-                file?.let { playAudio(it) }
-            }
-        }
-
-        private fun fetchAudio(context: Context, text: String): File? {
-            return try {
-                val url = URL("https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL/stream")
-                val conn = url.openConnection() as HttpURLConnection
-                conn.requestMethod = "POST"
-                conn.setRequestProperty("xi-api-key", BuildConfig.ELEVEN_LAB_KEY)
-                conn.setRequestProperty("Content-Type", "application/json")
-                conn.doOutput = true
-                val body = "{\"text\": \"$text\"}"
-                conn.outputStream.use { it.write(body.toByteArray()) }
-                if (conn.responseCode == HttpURLConnection.HTTP_OK) {
-                    val file = File.createTempFile("tts", ".mp3", context.cacheDir)
-                    conn.inputStream.use { input -> file.outputStream().use { input.copyTo(it) } }
-                    file
-                } else null
-            } catch (e: Exception) {
-                null
-            }
-        }
-
-        private fun playAudio(file: File) {
-            try {
-                val mp = MediaPlayer()
-                mp.setDataSource(file.absolutePath)
-                mp.setOnCompletionListener {
-                    it.release()
-                    file.delete()
-                }
-                mp.prepare()
-                mp.start()
-            } catch (_: Exception) {
-            }
-        }
     }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
@@ -12,12 +12,8 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.widget.RemoteViews
-import android.media.MediaPlayer
-import java.io.File
-import java.net.HttpURLConnection
-import java.net.URL
-import kotlin.concurrent.thread
-import kotlin.random.Random
+import com.jahi.pipelinetest.domain.GenerateAudioUseCase
+import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import com.jahi.pipelinetest.model.CustomEvent
 import java.time.Duration
 import java.time.LocalDateTime
@@ -61,7 +57,8 @@ class EventCountdownWidget : AppWidgetProvider() {
                 onUpdate(context, appWidgetManager, appWidgetIds)
             }
             ACTION_GENERATE_AUDIO -> {
-                generateAndPlay(context)
+                val vm = WidgetViewModel(GenerateAudioUseCase(context))
+                vm.playMotivationalAudio()
             }
         }
     }
@@ -111,12 +108,6 @@ class EventCountdownWidget : AppWidgetProvider() {
         private const val UPDATE_INTERVAL_MILLIS = 60000 // Update every minute
         const val ACTION_UPDATE_EVENT_WIDGET = "com.jahi.pipelinetest.UPDATE_EVENT_WIDGET"
         const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
-
-        private val motivationalSentences = listOf(
-            "You can achieve anything you set your mind to.",
-            "Believe in yourself and all that you are.",
-            "Every day is a chance to get better."
-        )
 
         private fun parseEventDateTime(dateString: String): LocalDateTime {
             return try {
@@ -295,46 +286,5 @@ class EventCountdownWidget : AppWidgetProvider() {
             return bitmap
         }
 
-        private fun generateAndPlay(context: Context) {
-            thread {
-                val text = motivationalSentences[Random.nextInt(motivationalSentences.size)]
-                val file = fetchAudio(context, text)
-                file?.let { playAudio(it) }
-            }
-        }
-
-        private fun fetchAudio(context: Context, text: String): File? {
-            return try {
-                val url = URL("https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL/stream")
-                val conn = url.openConnection() as HttpURLConnection
-                conn.requestMethod = "POST"
-                conn.setRequestProperty("xi-api-key", BuildConfig.ELEVEN_LAB_KEY)
-                conn.setRequestProperty("Content-Type", "application/json")
-                conn.doOutput = true
-                val body = "{\"text\": \"$text\"}"
-                conn.outputStream.use { it.write(body.toByteArray()) }
-                if (conn.responseCode == HttpURLConnection.HTTP_OK) {
-                    val file = File.createTempFile("tts", ".mp3", context.cacheDir)
-                    conn.inputStream.use { input -> file.outputStream().use { input.copyTo(it) } }
-                    file
-                } else null
-            } catch (e: Exception) {
-                null
-            }
-        }
-
-        private fun playAudio(file: File) {
-            try {
-                val mp = MediaPlayer()
-                mp.setDataSource(file.absolutePath)
-                mp.setOnCompletionListener {
-                    it.release()
-                    file.delete()
-                }
-                mp.prepare()
-                mp.start()
-            } catch (_: Exception) {
-            }
-        }
     }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/domain/GenerateAudioUseCase.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/domain/GenerateAudioUseCase.kt
@@ -1,0 +1,63 @@
+package com.jahi.pipelinetest.domain
+
+import android.content.Context
+import android.media.MediaPlayer
+import com.jahi.pipelinetest.BuildConfig
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.concurrent.thread
+import kotlin.random.Random
+
+class GenerateAudioUseCase(private val context: Context) {
+
+    private val motivationalSentences = listOf(
+        "You can achieve anything you set your mind to.",
+        "Believe in yourself and all that you are.",
+        "Every day is a chance to get better."
+    )
+
+    operator fun invoke() {
+        thread {
+            val text = motivationalSentences.random()
+            val file = fetchAudio(text)
+            file?.let { playAudio(it) }
+        }
+    }
+
+    private fun fetchAudio(text: String): File? {
+        return try {
+            val url = URL("https://api.elevenlabs.io/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL/stream")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("xi-api-key", BuildConfig.ELEVEN_LAB_KEY)
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.doOutput = true
+            val body = "{\"text\": \"$text\"}"
+            conn.outputStream.use { it.write(body.toByteArray()) }
+            if (conn.responseCode == HttpURLConnection.HTTP_OK) {
+                val file = File.createTempFile("tts", ".mp3", context.cacheDir)
+                conn.inputStream.use { input ->
+                    file.outputStream().use { input.copyTo(it) }
+                }
+                file
+            } else null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun playAudio(file: File) {
+        try {
+            val mp = MediaPlayer()
+            mp.setDataSource(file.absolutePath)
+            mp.setOnCompletionListener {
+                it.release()
+                file.delete()
+            }
+            mp.prepare()
+            mp.start()
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/viewmodel/WidgetViewModel.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/viewmodel/WidgetViewModel.kt
@@ -1,0 +1,13 @@
+package com.jahi.pipelinetest.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.jahi.pipelinetest.domain.GenerateAudioUseCase
+
+class WidgetViewModel(
+    private val generateAudioUseCase: GenerateAudioUseCase
+) : ViewModel() {
+
+    fun playMotivationalAudio() {
+        generateAudioUseCase()
+    }
+}


### PR DESCRIPTION
## Summary
- extract repeated audio generation logic into `GenerateAudioUseCase`
- create `WidgetViewModel` to invoke the use case
- update widgets to use the new view model and remove duplicated code

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_683c59c95918832ab1c63c01782547e0