### PR TITLE
Improve Settings field styles

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.platform.LocalContext
 import android.app.DatePickerDialog
@@ -34,6 +36,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.jahi.pipelinetest.model.CustomEvent
+import com.jahi.pipelinetest.ui.theme.Green500
+import com.jahi.pipelinetest.ui.theme.Slate100
+import com.jahi.pipelinetest.ui.theme.Slate400
+import com.jahi.pipelinetest.ui.theme.Slate700
+import com.jahi.pipelinetest.ui.theme.SurfaceDark
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -92,14 +99,14 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
             }
             if (tabIndex == 0) {
                 Column(modifier = Modifier.padding(16.dp)) {
-                    RowCheckbox("Show Year Countdown", showYear) { showYear = it }
-                    TextField(
+                        RowCheckbox("Show Year Countdown", showYear) { showYear = it }
+                    DarkTextField(
                         value = currentAge,
                         onValueChange = { currentAge = it },
                         label = { Text("Current Age") },
                         modifier = Modifier.fillMaxWidth()
                     )
-                    TextField(
+                    DarkTextField(
                         value = targetAge,
                         onValueChange = { targetAge = it },
                         label = { Text("Target Age") },
@@ -113,7 +120,7 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                         .verticalScroll(rememberScrollState())
                 ) {
                     events.forEachIndexed { index, event ->
-                        TextField(
+                        DarkTextField(
                             value = event.name,
                             onValueChange = { events[index] = event.copy(name = it) },
                             label = { Text("Event Name") },
@@ -133,7 +140,7 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                                     }
                                 }
                         ) {
-                            TextField(
+                            DarkTextField(
                                 value = event.date,
                                 onValueChange = {},
                                 readOnly = true,
@@ -167,6 +174,33 @@ private fun RowCheckbox(label: String, checked: Boolean, onChecked: (Boolean) ->
         Checkbox(checked = checked, onCheckedChange = onChecked)
         Text(text = label)
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DarkTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: @Composable (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+    readOnly: Boolean = false,
+    enabled: Boolean = true
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        readOnly = readOnly,
+        enabled = enabled,
+        label = label,
+        modifier = modifier,
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            containerColor = SurfaceDark,
+            focusedBorderColor = Green500,
+            unfocusedBorderColor = Slate700,
+            disabledBorderColor = Slate700,
+            cursorColor = Green500
+        )
+    )
 }
 
 private fun openDateTimePicker(

--- a/app/src/main/java/com/jahi/pipelinetest/ui/theme/Color.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/ui/theme/Color.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 // Base grayscale
 val Slate900 = Color(0xFF1A202C)
 val Slate800 = Color(0xFF2D3748)
+val Slate700 = Color(0xFF4A5568)
 val Slate100 = Color(0xFFF1F5F9)
 val Slate400 = Color(0xFF94A3B8)
 


### PR DESCRIPTION
## Summary
- add Slate700 color
- style settings screen fields with custom OutlinedTextField

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683c68e7d51c832aa1531799dfdf6c00