### PR TITLE
Add custom event alarms with notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 
 ### Countdown Timers
 - **Daily Countdown**: Track time remaining in the current day
-- **Yearly Countdown**: See how much time is left in the current year  
+- **Yearly Countdown**: See how much time is left in the current year
 - **Custom Events**: Create and track countdowns to important personal events and milestones
+- **Event Alarms**: Receive notifications when your custom events occur
 
 ### Life Visualization
 - **Life Hourglass**: Visualize your entire lifespan as hourglasses representing past, current, and future years
@@ -107,6 +108,7 @@ The app follows modern Android development practices:
 2. **Life Tab**: Explore your life timeline with the hourglass visualization  
 3. **Settings**: Configure your birthdate and manage custom countdown events
 4. **Widgets**: Add countdown widgets to your home screen for quick access
+5. **Notifications**: Receive alerts when an event alarm triggers
 
 ## Development
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,9 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/event_countdown_widget_info" />
         </receiver>
+        <receiver
+            android:name=".EventAlarmReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
@@ -1,0 +1,62 @@
+package com.jahi.pipelinetest
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
+class EventAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val eventName = intent.getStringExtra(EXTRA_EVENT_NAME) ?: return
+        if (intent.action == ACTION_DISMISS) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.cancel(eventName.hashCode())
+            return
+        }
+        createChannel(context)
+        val dismissIntent = Intent(context, EventAlarmReceiver::class.java).apply {
+            action = ACTION_DISMISS
+            putExtra(EXTRA_EVENT_NAME, eventName)
+        }
+        val dismissPending = PendingIntent.getBroadcast(
+            context,
+            eventName.hashCode(),
+            dismissIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(eventName)
+            .setContentText(context.getString(R.string.event_alarm_triggered))
+            .setAutoCancel(true)
+            .addAction(0, context.getString(R.string.dismiss), dismissPending)
+            .build()
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(eventName.hashCode(), notification)
+    }
+
+    private fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.event_alarm_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = context.getString(R.string.event_alarm_channel_description)
+            }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val EXTRA_EVENT_NAME = "event_name"
+        const val ACTION_DISMISS = "com.jahi.pipelinetest.ACTION_DISMISS_ALARM"
+        const val CHANNEL_ID = "event_alarm"
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
@@ -1,0 +1,58 @@
+package com.jahi.pipelinetest
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.jahi.pipelinetest.model.CustomEvent
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>) {
+    cancelEventAlarms(context)
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    events.forEachIndexed { index, event ->
+        if (event.date.isBlank()) return@forEachIndexed
+        val time = parseEventDateTime(event.date) ?: return@forEachIndexed
+        val triggerAt = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        if (triggerAt <= System.currentTimeMillis()) return@forEachIndexed
+        val intent = Intent(context, EventAlarmReceiver::class.java).apply {
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_NAME, event.name)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            index,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+    }
+}
+
+internal fun cancelEventAlarms(context: Context) {
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    for (i in 0 until 50) {
+        val intent = Intent(context, EventAlarmReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            i,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        pending?.let { alarmManager.cancel(it) }
+    }
+}
+
+private fun parseEventDateTime(dateString: String): LocalDateTime? {
+    return try {
+        LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    } catch (_: Exception) {
+        try {
+            LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay()
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.platform.LocalContext
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import com.jahi.pipelinetest.scheduleEventAlarms
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -80,9 +81,11 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                     val intent = Intent(EventCountdownWidget.ACTION_UPDATE_EVENT_WIDGET)
                     intent.setPackage(context.packageName)
                     context.sendBroadcast(intent)
-                    
+
+                    scheduleEventAlarms(context, events)
+
                     onDismiss()
-                }) { Text("Save") }
+                }) { Text("Save") } 
             }
         }
     ) { innerPadding ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="circular_progress_widget_description">Shows elapsed time with circular progress</string>
     <string name="daily_countdown_widget_description">Counts down to the end of the day</string>
     <string name="event_countdown_widget_description">Shows time remaining until your next event</string>
+    <string name="event_alarm_channel_name">Event Alarms</string>
+    <string name="event_alarm_channel_description">Notifications for scheduled events</string>
+    <string name="event_alarm_triggered">Event time reached</string>
+    <string name="dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `EventAlarmReceiver` and scheduler helpers
- trigger alarm scheduling from settings
- register new receiver in manifest
- provide strings and README notes for event alarms

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_683d3c1044c0832abd0e8941e898e7a2