### PR TITLE
Add custom event alarms with notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 
 ### Countdown Timers
 - **Daily Countdown**: Track time remaining in the current day
-- **Yearly Countdown**: See how much time is left in the current year  
+- **Yearly Countdown**: See how much time is left in the current year
 - **Custom Events**: Create and track countdowns to important personal events and milestones
+- **Event Alarms**: Receive notifications when your custom events occur
 
 ### Life Visualization
 - **Life Hourglass**: Visualize your entire lifespan as hourglasses representing past, current, and future years
@@ -30,6 +31,7 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 - **Java**: JDK 17 or higher
 - **Build Tools**: Gradle 8.10.2+, Android Gradle Plugin 8.8.2
 - **Target SDK**: API level 35 (Android 14)
+- **Exact Alarm Permission**: Required on Android 12+ to schedule event alarms
 
 ## Build Instructions
 
@@ -107,6 +109,7 @@ The app follows modern Android development practices:
 2. **Life Tab**: Explore your life timeline with the hourglass visualization  
 3. **Settings**: Configure your birthdate and manage custom countdown events
 4. **Widgets**: Add countdown widgets to your home screen for quick access
+5. **Notifications**: Receive alerts when an event alarm triggers and dismiss them from the notification
 
 ## Development
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" tools:targetApi="31" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" tools:targetApi="33" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -63,6 +66,9 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/event_countdown_widget_info" />
         </receiver>
+        <receiver
+            android:name=".EventAlarmReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
@@ -1,0 +1,21 @@
+package com.jahi.pipelinetest
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Parse a date string that may contain a full date-time or just a date.
+ * Returns null if parsing fails.
+ */
+internal fun parseEventDateTime(dateString: String): LocalDateTime? {
+    return try {
+        LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    } catch (_: Exception) {
+        try {
+            LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay()
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
@@ -1,0 +1,67 @@
+package com.jahi.pipelinetest
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
+class EventAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val eventName = intent.getStringExtra(EXTRA_EVENT_NAME) ?: return
+        val eventId = intent.getIntExtra(EXTRA_EVENT_ID, INVALID_EVENT_ID)
+        val notificationId = if (eventId != INVALID_EVENT_ID) eventId else eventName.hashCode()
+        if (intent.action == ACTION_DISMISS) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.cancel(notificationId)
+            return
+        }
+        createChannel(context)
+        val dismissIntent = Intent(context, EventAlarmReceiver::class.java).apply {
+            action = ACTION_DISMISS
+            putExtra(EXTRA_EVENT_NAME, eventName)
+            putExtra(EXTRA_EVENT_ID, eventId)
+        }
+        val dismissPending = PendingIntent.getBroadcast(
+            context,
+            notificationId,
+            dismissIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(eventName)
+            .setContentText(context.getString(R.string.event_alarm_triggered))
+            .setAutoCancel(true)
+            .addAction(0, context.getString(R.string.dismiss), dismissPending)
+            .build()
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(notificationId, notification)
+    }
+
+    private fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.event_alarm_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = context.getString(R.string.event_alarm_channel_description)
+            }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val EXTRA_EVENT_NAME = "event_name"
+        const val EXTRA_EVENT_ID = "event_id"
+        const val INVALID_EVENT_ID = -1
+        const val ACTION_DISMISS = "com.jahi.pipelinetest.ACTION_DISMISS_ALARM"
+        const val CHANNEL_ID = "event_alarm"
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
@@ -1,0 +1,45 @@
+package com.jahi.pipelinetest
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.jahi.pipelinetest.model.CustomEvent
+import com.jahi.pipelinetest.parseEventDateTime
+import java.time.ZoneId
+
+internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>) {
+    cancelEventAlarms(context, events.size)
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    events.forEachIndexed { index, event ->
+        if (event.date.isBlank()) return@forEachIndexed
+        val time = parseEventDateTime(event.date) ?: return@forEachIndexed
+        val triggerAt = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        if (triggerAt <= System.currentTimeMillis()) return@forEachIndexed
+        val intent = Intent(context, EventAlarmReceiver::class.java).apply {
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_NAME, event.name)
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_ID, index)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            index,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+    }
+}
+
+internal fun cancelEventAlarms(context: Context, count: Int) {
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    for (i in 0 until count) {
+        val intent = Intent(context, EventAlarmReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            i,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        pending?.let { alarmManager.cancel(it) }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
@@ -15,12 +15,13 @@ import android.widget.RemoteViews
 import com.jahi.pipelinetest.domain.GenerateAudioUseCase
 import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import com.jahi.pipelinetest.model.CustomEvent
+import com.jahi.pipelinetest.parseEventDateTime
 import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import com.jahi.pipelinetest.Prefs
-import java.time.LocalDate
 
 class EventCountdownWidget : AppWidgetProvider() {
 
@@ -109,21 +110,6 @@ class EventCountdownWidget : AppWidgetProvider() {
         const val ACTION_UPDATE_EVENT_WIDGET = "com.jahi.pipelinetest.UPDATE_EVENT_WIDGET"
         const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
 
-        private fun parseEventDateTime(dateString: String): LocalDateTime {
-            return try {
-                // Try parsing as LocalDateTime first
-                LocalDateTime.parse(dateString)
-            } catch (e: Exception) {
-                try {
-                    // If that fails, try parsing as LocalDate and convert to LocalDateTime
-                    LocalDate.parse(dateString).atStartOfDay()
-                } catch (e2: Exception) {
-                    // If both fail, throw the original exception
-                    throw e
-                }
-            }
-        }
-
         internal fun updateAppWidget(
             context: Context,
             appWidgetManager: AppWidgetManager,
@@ -142,28 +128,23 @@ class EventCountdownWidget : AppWidgetProvider() {
                     views.setTextViewText(R.id.time_text, "--:--")
                     views.setImageViewResource(R.id.circular_progress_view, R.drawable.widget_background)
                 } else {
-                    // Filter out past events and find next upcoming event
-                    val futureEvents = events.filter { event ->
-                        try {
-                            val eventDateTime = parseEventDateTime(event.date)
-                            eventDateTime.isAfter(now)
-                        } catch (e: Exception) {
-                            false
-                        }
+                    // Parse events and find next upcoming one
+                    val parsed = events.mapNotNull { e ->
+                        parseEventDateTime(e.date)?.let { dt -> e to dt }
                     }
-                    
-                    val nextEvent = futureEvents.minByOrNull { event ->
-                        val eventDateTime = parseEventDateTime(event.date)
-                        ChronoUnit.MILLIS.between(now, eventDateTime)
+                    val futureEvents = parsed.filter { it.second.isAfter(now) }
+                    val nextPair = futureEvents.minByOrNull { pair ->
+                        ChronoUnit.MILLIS.between(now, pair.second)
                     }
-                    
-                    if (nextEvent == null) {
+
+                    if (nextPair == null) {
                         views.setTextViewText(R.id.event_name, "No upcoming events")
                         views.setTextViewText(R.id.time_text, "--:--")
                         views.setImageViewResource(R.id.circular_progress_view, R.drawable.widget_background)
                     } else {
                         // Calculate remaining time to event
-                        val eventTime = parseEventDateTime(nextEvent.date)
+                        val nextEvent = nextPair.first
+                        val eventTime = nextPair.second
                         val remainingDuration = Duration.between(now, eventTime)
                         val remainingSeconds = remainingDuration.seconds
                         

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.platform.LocalContext
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import com.jahi.pipelinetest.scheduleEventAlarms
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -80,9 +81,11 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                     val intent = Intent(EventCountdownWidget.ACTION_UPDATE_EVENT_WIDGET)
                     intent.setPackage(context.packageName)
                     context.sendBroadcast(intent)
-                    
+
+                    scheduleEventAlarms(context, events)
+
                     onDismiss()
-                }) { Text("Save") }
+                }) { Text("Save") } 
             }
         }
     ) { innerPadding ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="circular_progress_widget_description">Shows elapsed time with circular progress</string>
     <string name="daily_countdown_widget_description">Counts down to the end of the day</string>
     <string name="event_countdown_widget_description">Shows time remaining until your next event</string>
+    <string name="event_alarm_channel_name">Event Alarms</string>
+    <string name="event_alarm_channel_description">Notifications for scheduled events</string>
+    <string name="event_alarm_triggered">Event time reached</string>
+    <string name="dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `EventAlarmReceiver` and scheduler helpers
- trigger alarm scheduling from settings
- register new receiver in manifest
- provide strings and README notes for event alarms
- refine event alarms with unique IDs and exact alarm permission

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683d3c1044c0832abd0e8941e898e7a2