### PR TITLE
Add dismissible event alarm notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 
 ### Countdown Timers
 - **Daily Countdown**: Track time remaining in the current day
-- **Yearly Countdown**: See how much time is left in the current year  
+- **Yearly Countdown**: See how much time is left in the current year
 - **Custom Events**: Create and track countdowns to important personal events and milestones
+- **Event Alarms**: Schedule alarms for custom events that show dismissible notifications
 
 ### Life Visualization
 - **Life Hourglass**: Visualize your entire lifespan as hourglasses representing past, current, and future years
@@ -30,6 +31,7 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 - **Java**: JDK 17 or higher
 - **Build Tools**: Gradle 8.10.2+, Android Gradle Plugin 8.8.2
 - **Target SDK**: API level 35 (Android 14)
+- **Permissions**: `SCHEDULE_EXACT_ALARM` required on Android 12+ so event alarms fire on time
 
 ## Build Instructions
 
@@ -107,6 +109,7 @@ The app follows modern Android development practices:
 2. **Life Tab**: Explore your life timeline with the hourglass visualization  
 3. **Settings**: Configure your birthdate and manage custom countdown events
 4. **Widgets**: Add countdown widgets to your home screen for quick access
+5. **Notifications**: Event alarms trigger dismissible notifications when the event time is reached
 
 ## Development
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Required for exact alarms on Android 12+ -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -63,6 +66,9 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/event_countdown_widget_info" />
         </receiver>
+        <receiver
+            android:name=".EventAlarmReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
@@ -1,0 +1,28 @@
+package com.jahi.pipelinetest
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+/**
+ * Parse a date string that may be in ISO_LOCAL_DATE or ISO_LOCAL_DATE_TIME format.
+ * @throws DateTimeParseException if the date cannot be parsed.
+ */
+fun parseEventDateTime(dateString: String): LocalDateTime {
+    return try {
+        LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    } catch (e: DateTimeParseException) {
+        LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE).atStartOfDay()
+    }
+}
+
+/**
+ * Parses the date string and returns null if it cannot be parsed.
+ */
+fun parseEventDateTimeOrNull(dateString: String): LocalDateTime? =
+    try {
+        parseEventDateTime(dateString)
+    } catch (_: DateTimeParseException) {
+        null
+    }

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
@@ -1,0 +1,65 @@
+package com.jahi.pipelinetest
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
+class EventAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val eventName = intent.getStringExtra(EXTRA_EVENT_NAME) ?: return
+        val eventId = intent.getIntExtra(EXTRA_EVENT_ID, -1)
+        val notificationId = if (eventId != -1) eventId else eventName.hashCode()
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (intent.action == ACTION_DISMISS) {
+            nm.cancel(notificationId)
+            return
+        }
+        createChannel(context)
+        val dismissIntent = Intent(context, EventAlarmReceiver::class.java).apply {
+            action = ACTION_DISMISS
+            putExtra(EXTRA_EVENT_NAME, eventName)
+            putExtra(EXTRA_EVENT_ID, eventId)
+        }
+        val dismissPending = PendingIntent.getBroadcast(
+            context,
+            notificationId,
+            dismissIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(eventName)
+            .setContentText(context.getString(R.string.event_alarm_triggered))
+            .setAutoCancel(true)
+            .addAction(0, context.getString(R.string.dismiss), dismissPending)
+            .build()
+        nm.notify(notificationId, notification)
+    }
+
+    private fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.event_alarm_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = context.getString(R.string.event_alarm_channel_description)
+            }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val EXTRA_EVENT_NAME = "event_name"
+        const val EXTRA_EVENT_ID = "event_id"
+        const val ACTION_DISMISS = "com.jahi.pipelinetest.ACTION_DISMISS_ALARM"
+        const val CHANNEL_ID = "event_alarm"
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
@@ -1,0 +1,47 @@
+package com.jahi.pipelinetest
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.jahi.pipelinetest.model.CustomEvent
+import com.jahi.pipelinetest.parseEventDateTimeOrNull
+import java.time.ZoneId
+
+internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>) {
+    cancelEventAlarms(context)
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    events.take(MAX_ALARMS).forEachIndexed { index, event ->
+        if (event.date.isBlank()) return@forEachIndexed
+        val time = parseEventDateTimeOrNull(event.date) ?: return@forEachIndexed
+        val triggerAt = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        if (triggerAt <= System.currentTimeMillis()) return@forEachIndexed
+        val intent = Intent(context, EventAlarmReceiver::class.java).apply {
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_NAME, event.name)
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_ID, index)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            index,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+    }
+}
+
+internal fun cancelEventAlarms(context: Context) {
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    for (i in 0 until MAX_ALARMS) {
+        val intent = Intent(context, EventAlarmReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            i,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        pending?.let { alarmManager.cancel(it) }
+    }
+}
+
+private const val MAX_ALARMS = 50

--- a/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import com.jahi.pipelinetest.Prefs
 import java.time.LocalDate
+import com.jahi.pipelinetest.parseEventDateTime
 
 class EventCountdownWidget : AppWidgetProvider() {
 
@@ -109,20 +110,6 @@ class EventCountdownWidget : AppWidgetProvider() {
         const val ACTION_UPDATE_EVENT_WIDGET = "com.jahi.pipelinetest.UPDATE_EVENT_WIDGET"
         const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
 
-        private fun parseEventDateTime(dateString: String): LocalDateTime {
-            return try {
-                // Try parsing as LocalDateTime first
-                LocalDateTime.parse(dateString)
-            } catch (e: Exception) {
-                try {
-                    // If that fails, try parsing as LocalDate and convert to LocalDateTime
-                    LocalDate.parse(dateString).atStartOfDay()
-                } catch (e2: Exception) {
-                    // If both fail, throw the original exception
-                    throw e
-                }
-            }
-        }
 
         internal fun updateAppWidget(
             context: Context,

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.platform.LocalContext
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import com.jahi.pipelinetest.scheduleEventAlarms
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -80,9 +81,11 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                     val intent = Intent(EventCountdownWidget.ACTION_UPDATE_EVENT_WIDGET)
                     intent.setPackage(context.packageName)
                     context.sendBroadcast(intent)
-                    
+
+                    scheduleEventAlarms(context, events)
+
                     onDismiss()
-                }) { Text("Save") }
+                }) { Text("Save") } 
             }
         }
     ) { innerPadding ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="circular_progress_widget_description">Shows elapsed time with circular progress</string>
     <string name="daily_countdown_widget_description">Counts down to the end of the day</string>
     <string name="event_countdown_widget_description">Shows time remaining until your next event</string>
+    <string name="event_alarm_channel_name">Event Alarms</string>
+    <string name="event_alarm_channel_description">Notifications for scheduled events</string>
+    <string name="event_alarm_triggered">Event time reached</string>
+    <string name="dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `parseEventDateTime` helpers
- ensure alarms use unique IDs and respect a maximum
- add exact alarm permission for Android 12+
- show dismissible notifications when alarms fire
- document alarm permission and dismissible notifications in README

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683d3c1044c0832abd0e8941e898e7a2