### PR TITLE
Add custom event alarms with notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 
 ### Countdown Timers
 - **Daily Countdown**: Track time remaining in the current day
-- **Yearly Countdown**: See how much time is left in the current year  
+- **Yearly Countdown**: See how much time is left in the current year
 - **Custom Events**: Create and track countdowns to important personal events and milestones
+- **Event Alarms**: Set alarms that trigger dismissible notifications when your custom events occur
 
 ### Life Visualization
 - **Life Hourglass**: Visualize your entire lifespan as hourglasses representing past, current, and future years
@@ -107,6 +108,8 @@ The app follows modern Android development practices:
 2. **Life Tab**: Explore your life timeline with the hourglass visualization  
 3. **Settings**: Configure your birthdate and manage custom countdown events
 4. **Widgets**: Add countdown widgets to your home screen for quick access
+5. **Notifications**: Receive alerts when an event alarm triggers
+6. **Permissions**: On Android 12+ grant the exact alarm permission so alarms can fire on time
 
 ## Development
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Allow scheduling exact alarms on Android 12+ -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -63,6 +66,9 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/event_countdown_widget_info" />
         </receiver>
+        <receiver
+            android:name=".EventAlarmReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
@@ -1,0 +1,19 @@
+package com.jahi.pipelinetest
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+internal fun parseEventDateTimeOrNull(dateString: String): LocalDateTime? {
+    return try {
+        LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    } catch (_: DateTimeParseException) {
+        try {
+            LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE)
+                .atStartOfDay()
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
@@ -1,0 +1,67 @@
+package com.jahi.pipelinetest
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
+class EventAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val eventName = intent.getStringExtra(EXTRA_EVENT_NAME) ?: return
+        val eventId = intent.getIntExtra(EXTRA_EVENT_ID, DEFAULT_EVENT_ID)
+        val notificationId = if (eventId == DEFAULT_EVENT_ID) eventName.hashCode() else eventId
+        if (intent.action == ACTION_DISMISS) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.cancel(notificationId)
+            return
+        }
+        createChannel(context)
+        val dismissIntent = Intent(context, EventAlarmReceiver::class.java).apply {
+            action = ACTION_DISMISS
+            putExtra(EXTRA_EVENT_NAME, eventName)
+            putExtra(EXTRA_EVENT_ID, eventId)
+        }
+        val dismissPending = PendingIntent.getBroadcast(
+            context,
+            notificationId,
+            dismissIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_event_notification)
+            .setContentTitle(eventName)
+            .setContentText(context.getString(R.string.event_alarm_triggered))
+            .setAutoCancel(true)
+            .addAction(0, context.getString(R.string.dismiss), dismissPending)
+            .build()
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(notificationId, notification)
+    }
+
+    private fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.event_alarm_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = context.getString(R.string.event_alarm_channel_description)
+            }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val EXTRA_EVENT_NAME = "event_name"
+        const val EXTRA_EVENT_ID = "event_id"
+        const val DEFAULT_EVENT_ID = -1
+        const val ACTION_DISMISS = "com.jahi.pipelinetest.ACTION_DISMISS_ALARM"
+        const val CHANNEL_ID = "event_alarm"
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
@@ -1,0 +1,56 @@
+package com.jahi.pipelinetest
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.jahi.pipelinetest.model.CustomEvent
+import java.time.ZoneId
+import com.jahi.pipelinetest.parseEventDateTimeOrNull
+
+private const val MAX_ALARMS = 50
+
+internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>) {
+    cancelEventAlarms(context)
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    events.take(MAX_ALARMS).forEachIndexed { index, event ->
+        if (event.date.isBlank()) return@forEachIndexed
+        val time = parseEventDateTimeOrNull(event.date) ?: return@forEachIndexed
+        val triggerAt = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        if (triggerAt <= System.currentTimeMillis()) return@forEachIndexed
+        val intent = Intent(context, EventAlarmReceiver::class.java).apply {
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_NAME, event.name)
+            putExtra(EventAlarmReceiver.EXTRA_EVENT_ID, index)
+        }
+        val pending = PendingIntent.getBroadcast(
+            context,
+            index,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (alarmManager.canScheduleExactAlarms()) {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+            } else {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+            }
+        } else {
+            alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+        }
+    }
+}
+
+internal fun cancelEventAlarms(context: Context) {
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    for (i in 0 until MAX_ALARMS) {
+        val intent = Intent(context, EventAlarmReceiver::class.java)
+        val pending = PendingIntent.getBroadcast(
+            context,
+            i,
+            intent,
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        )
+        pending?.let { alarmManager.cancel(it) }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import com.jahi.pipelinetest.Prefs
 import java.time.LocalDate
+import com.jahi.pipelinetest.parseEventDateTimeOrNull
 
 class EventCountdownWidget : AppWidgetProvider() {
 
@@ -110,18 +111,8 @@ class EventCountdownWidget : AppWidgetProvider() {
         const val ACTION_GENERATE_AUDIO = "com.jahi.pipelinetest.GENERATE_AUDIO"
 
         private fun parseEventDateTime(dateString: String): LocalDateTime {
-            return try {
-                // Try parsing as LocalDateTime first
-                LocalDateTime.parse(dateString)
-            } catch (e: Exception) {
-                try {
-                    // If that fails, try parsing as LocalDate and convert to LocalDateTime
-                    LocalDate.parse(dateString).atStartOfDay()
-                } catch (e2: Exception) {
-                    // If both fail, throw the original exception
-                    throw e
-                }
-            }
+            return parseEventDateTimeOrNull(dateString)
+                ?: throw IllegalArgumentException("Invalid date format: $dateString")
         }
 
         internal fun updateAppWidget(

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.platform.LocalContext
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import com.jahi.pipelinetest.scheduleEventAlarms
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -80,9 +81,11 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                     val intent = Intent(EventCountdownWidget.ACTION_UPDATE_EVENT_WIDGET)
                     intent.setPackage(context.packageName)
                     context.sendBroadcast(intent)
-                    
+
+                    scheduleEventAlarms(context, events)
+
                     onDismiss()
-                }) { Text("Save") }
+                }) { Text("Save") } 
             }
         }
     ) { innerPadding ->

--- a/app/src/main/res/drawable/ic_event_notification.xml
+++ b/app/src/main/res/drawable/ic_event_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zM18,16v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.63,5.36 6,7.92 6,11v5l-1.99,2v1h14v-1l-2,-2z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="circular_progress_widget_description">Shows elapsed time with circular progress</string>
     <string name="daily_countdown_widget_description">Counts down to the end of the day</string>
     <string name="event_countdown_widget_description">Shows time remaining until your next event</string>
+    <string name="event_alarm_channel_name">Event Alarms</string>
+    <string name="event_alarm_channel_description">Notifications for scheduled events</string>
+    <string name="event_alarm_triggered">Event time reached</string>
+    <string name="dismiss">Dismiss</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `EventAlarmReceiver` and scheduler helpers
- trigger alarm scheduling from settings
- register new receiver in manifest
- provide strings and README notes for event alarms
- handle exact alarm permission and unique notification IDs

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683d3c1044c0832abd0e8941e898e7a2