### PR TITLE
Improve event scheduling notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 - **Java**: JDK 17 or higher
 - **Build Tools**: Gradle 8.10.2+, Android Gradle Plugin 8.8.2
 - **Target SDK**: API level 35 (Android 14)
-- **Permissions**: Requires the `SCHEDULE_EXACT_ALARM` permission for precise event alarms
+- **Permissions**: Requires the `SCHEDULE_EXACT_ALARM` and `POST_NOTIFICATIONS` permissions for event alarms and notifications
 
 ## Build Instructions
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
@@ -11,8 +11,9 @@ import com.jahi.pipelinetest.parseEventDateTimeOrNull
 
 private const val MAX_ALARMS = 50
 
-internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>) {
+internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>): Int {
     val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    var count = 0
     events.take(MAX_ALARMS).forEach { event ->
         if (event.date.isBlank()) return@forEach
         val time = parseEventDateTimeOrNull(event.date) ?: return@forEach
@@ -37,7 +38,9 @@ internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>) {
         } else {
             alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
         }
+        count++
     }
+    return count
 }
 
 internal fun cancelEventAlarms(context: Context, events: List<CustomEvent>) {

--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -1,6 +1,10 @@
 package com.jahi.pipelinetest
 
 import android.os.Bundle
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -37,6 +41,19 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val prefs = Prefs(this)
         val viewModel = ViewModelProvider(this, MainViewModelFactory(prefs))[MainViewModel::class.java]
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    REQUEST_NOTIFICATION_PERMISSION
+                )
+            }
+        }
         enableEdgeToEdge()
         setContent {
             PipelineTestTheme {
@@ -110,6 +127,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    companion object {
+        private const val REQUEST_NOTIFICATION_PERMISSION = 100
     }
 }
 

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -85,7 +85,14 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                     context.sendBroadcast(intent)
 
                     cancelEventAlarms(context, oldEvents)
-                    scheduleEventAlarms(context, events)
+                    val scheduled = scheduleEventAlarms(context, events)
+                    if (scheduled > 0) {
+                        android.widget.Toast.makeText(
+                            context,
+                            context.getString(R.string.events_scheduled),
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    }
 
                     onDismiss()
                 }) { Text("Save") }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="event_alarm_channel_description">Notifications for scheduled events</string>
     <string name="event_alarm_triggered">Event time reached</string>
     <string name="dismiss">Dismiss</string>
+    <string name="events_scheduled">Event alarms scheduled</string>
 </resources>


### PR DESCRIPTION
## Summary
- request notification permission on startup
- confirm event alarms are scheduled with a toast
- return the number of alarms created
- update Android manifest with POST_NOTIFICATIONS
- document new permission requirement

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_683d60d49638832a90feaaff613b1c46