### PR TITLE
Fix delayed event notifications

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmReceiver.kt
@@ -37,6 +37,7 @@ class EventAlarmReceiver : BroadcastReceiver() {
             .setContentTitle(eventName)
             .setContentText(context.getString(R.string.event_alarm_triggered))
             .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .addAction(0, context.getString(R.string.dismiss), dismissPending)
             .build()
         val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventAlarmScheduler.kt
@@ -31,10 +31,12 @@ internal fun scheduleEventAlarms(context: Context, events: List<CustomEvent>): I
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (alarmManager.canScheduleExactAlarms()) {
-                alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pending)
             } else {
                 alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAt, pending)
             }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pending)
         } else {
             alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
         }


### PR DESCRIPTION
## Summary
- deliver event alarms even if the device is idle
- show event notifications with high priority

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_683d66006190832aa2dc2f4157ef4097