### PR TITLE
Add history tab for past events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Time Fomo is an Android application built with Kotlin and Jetpack Compose that h
 - **Yearly Countdown**: See how much time is left in the current year
 - **Custom Events**: Create and track countdowns to important personal events and milestones
 - **Event Alarms**: Save events in Settings to automatically schedule alarms with dismissible notifications when your custom events occur
+- **Event History**: View past custom events from the new History tab in Settings, listed most recent first
 
 ### Life Visualization
 - **Life Hourglass**: Visualize your entire lifespan as hourglasses representing past, current, and future years

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -45,11 +45,13 @@ import com.jahi.pipelinetest.ui.theme.Green500
 import com.jahi.pipelinetest.ui.theme.Green600
 import com.jahi.pipelinetest.ui.theme.OutlineDark
 import com.jahi.pipelinetest.ui.theme.SurfaceDark
+import com.jahi.pipelinetest.ui.theme.Slate400
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import android.content.Intent
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -119,7 +121,9 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
             TabRow(selectedTabIndex = tabIndex) {
                 Tab(selected = tabIndex == 0, onClick = { tabIndex = 0 }) { Text("General") }
                 Tab(selected = tabIndex == 1, onClick = { tabIndex = 1 }) { Text("Events") }
+                Tab(selected = tabIndex == 2, onClick = { tabIndex = 2 }) { Text("History") }
             }
+
             if (tabIndex == 0) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     RowCheckbox("Show Year Countdown", showYear) { showYear = it }
@@ -136,16 +140,15 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
-            } else {
+            } else if (tabIndex == 1) {
                 Column(
                     modifier = Modifier
                         .padding(16.dp)
                         .verticalScroll(rememberScrollState())
                 ) {
                     val currentInstant by viewModel.now.collectAsState()
-                    val systemZone = remember { ZoneId.systemDefault() }
                     val currentLocalDateTimeForEditCheck = remember(currentInstant) {
-                        LocalDateTime.ofInstant(currentInstant, systemZone)
+                        LocalDateTime.ofInstant(currentInstant, ZoneId.systemDefault())
                     }
 
                     events.forEachIndexed { index, event ->
@@ -200,6 +203,46 @@ fun SettingsScreen(viewModel: MainViewModel, onDismiss: () -> Unit) {
                     }
                     Button(onClick = { events.add(CustomEvent()) }, modifier = Modifier.padding(top = 8.dp)) {
                         Text("Add Event")
+                    }
+                }
+            } else {
+                val nowInstant by viewModel.now.collectAsState()
+                val nowLocal = remember(nowInstant) {
+                    LocalDateTime.ofInstant(nowInstant, ZoneId.systemDefault())
+                }
+                val allEventsParsedAndSorted = remember(events) {
+                    events
+                        .mapNotNull { ev ->
+                            parseEventDateTimeOrNull(ev.date)?.let { time -> ev to time }
+                        }
+                        .sortedByDescending { (_, time) -> time }
+                }
+                val pastEvents = remember(allEventsParsedAndSorted, nowLocal) {
+                    allEventsParsedAndSorted.filter { (_, time) -> time.isBefore(nowLocal) }
+                }
+
+                Column(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    if (pastEvents.isEmpty()) {
+                        Text("No past events", color = Slate400)
+                    } else {
+                        val zone = ZoneId.systemDefault()
+                        pastEvents.forEach { (event, time) ->
+                            val formattedDate = remember(time) {
+                                time.atZone(zone).format(
+                                    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
+                                )
+                            }
+                            Text(event.name)
+                            Text(
+                                formattedDate,
+                                color = Slate400,
+                                modifier = Modifier.padding(bottom = 8.dp)
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add a new History tab in Settings to show past custom events
- document the History tab in README
- improve past event sorting and timezone handling

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683dbb69b4a4832a982d9ed48ff4bbdf