### PR TITLE
Fix TaskRepository list type mismatch

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/repository/TaskRepository.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/repository/TaskRepository.kt
@@ -17,7 +17,7 @@ class TaskRepository(private val prefs: Prefs) {
     
     private fun saveTasks(tasks: List<Task>) {
         prefs.tasks = tasks.toMutableList()
-        _tasks.value = tasks
+        _tasks.value = tasks.toMutableList()
     }
     
     fun addTask(task: Task) {


### PR DESCRIPTION
## Summary
- maintain MutableList in TaskRepository's state flow

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683dfe0b4c10832ab1d6cff5c7d61e23