### PR TITLE
Enable tasks screen

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -38,6 +38,7 @@ import com.jahi.pipelinetest.repository.TaskRepository
 import com.jahi.pipelinetest.domain.*
 import com.jahi.pipelinetest.viewmodel.TaskViewModel
 import com.jahi.pipelinetest.viewmodel.TaskViewModelFactory
+import com.jahi.pipelinetest.TaskOverviewScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
@@ -59,7 +60,8 @@ class MainActivity : ComponentActivity() {
             getTasksForEventUseCase,
             updateTaskUseCase,
             deleteTaskUseCase,
-            toggleTaskCompletionUseCase
+            toggleTaskCompletionUseCase,
+            taskRepository
         )
         val taskViewModel = ViewModelProvider(this, taskViewModelFactory)[TaskViewModel::class.java]
         
@@ -137,13 +139,26 @@ class MainActivity : ComponentActivity() {
                                         indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
                                     )
                                 )
+                                NavigationBarItem(
+                                    selected = viewModel.screen == 2,
+                                    onClick = { viewModel.selectScreen(2) },
+                                    label = { Text("Tasks") },
+                                    icon = { },
+                                    colors = NavigationBarItemDefaults.colors(
+                                        selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
+                                        selectedTextColor = com.jahi.pipelinetest.ui.theme.Slate100,
+                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
+                                    )
+                                )
                             }
                         }
                     ) { innerPadding ->
-                        if (viewModel.screen == 0) {
-                            CountdownsScreen(viewModel, taskViewModel, Modifier.padding(innerPadding))
-                        } else {
-                            LifeHourglassScreen(viewModel, Modifier.padding(innerPadding))
+                        when (viewModel.screen) {
+                            0 -> CountdownsScreen(viewModel, taskViewModel, Modifier.padding(innerPadding))
+                            1 -> LifeHourglassScreen(viewModel, Modifier.padding(innerPadding))
+                            else -> TaskOverviewScreen(viewModel, taskViewModel, Modifier.padding(innerPadding))
                         }
                     }
                 }

--- a/app/src/main/java/com/jahi/pipelinetest/TaskOverviewScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/TaskOverviewScreen.kt
@@ -1,0 +1,43 @@
+package com.jahi.pipelinetest
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.jahi.pipelinetest.ui.components.TaskList
+import com.jahi.pipelinetest.viewmodel.TaskViewModel
+
+@Composable
+fun TaskOverviewScreen(
+    mainViewModel: MainViewModel,
+    taskViewModel: TaskViewModel,
+    modifier: Modifier = Modifier
+) {
+    val tasks = taskViewModel.allTasks.collectAsState().value
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        mainViewModel.events.forEach { event ->
+            Text(
+                text = event.name,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            val eventTasks = tasks.filter { it.eventId == event.id }
+            TaskList(
+                eventId = event.id,
+                tasks = eventTasks,
+                taskViewModel = taskViewModel,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/viewmodel/TaskViewModel.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/viewmodel/TaskViewModel.kt
@@ -8,21 +8,29 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import com.jahi.pipelinetest.domain.*
 import com.jahi.pipelinetest.model.Task
+import com.jahi.pipelinetest.repository.TaskRepository
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
 
 class TaskViewModel(
     private val addTaskToEventUseCase: AddTaskToEventUseCase,
     private val getTasksForEventUseCase: GetTasksForEventUseCase,
     private val updateTaskUseCase: UpdateTaskUseCase,
     private val deleteTaskUseCase: DeleteTaskUseCase,
-    private val toggleTaskCompletionUseCase: ToggleTaskCompletionUseCase
+    private val toggleTaskCompletionUseCase: ToggleTaskCompletionUseCase,
+    private val taskRepository: com.jahi.pipelinetest.repository.TaskRepository
 ) : ViewModel() {
 
     private val _tasks = MutableStateFlow<List<Task>>(emptyList())
     val tasks: StateFlow<List<Task>> = _tasks.asStateFlow()
+
+    val allTasks: StateFlow<List<Task>> =
+        taskRepository.tasks
+            .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.Eagerly, emptyList())
 
     var isAddingTask by mutableStateOf(false)
         private set
@@ -90,7 +98,8 @@ class TaskViewModelFactory(
     private val getTasksForEventUseCase: GetTasksForEventUseCase,
     private val updateTaskUseCase: UpdateTaskUseCase,
     private val deleteTaskUseCase: DeleteTaskUseCase,
-    private val toggleTaskCompletionUseCase: ToggleTaskCompletionUseCase
+    private val toggleTaskCompletionUseCase: ToggleTaskCompletionUseCase,
+    private val taskRepository: com.jahi.pipelinetest.repository.TaskRepository
 ) : ViewModelProvider.Factory {
     
     @Suppress("UNCHECKED_CAST")
@@ -101,7 +110,8 @@ class TaskViewModelFactory(
                 getTasksForEventUseCase,
                 updateTaskUseCase,
                 deleteTaskUseCase,
-                toggleTaskCompletionUseCase
+                toggleTaskCompletionUseCase,
+                taskRepository
             ) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")


### PR DESCRIPTION
## Summary
- show a new Tasks screen through bottom navigation
- expose all tasks via `TaskViewModel`

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_683e021a12b4832aa323fe8f9b4a7849