### PR TITLE
Add task deadlines and alarms

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,6 +74,9 @@
         <receiver
             android:name=".EventAlarmReceiver"
             android:exported="false" />
+        <receiver
+            android:name=".TaskAlarmReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DateUtils.kt
@@ -20,3 +20,7 @@ internal fun parseEventDateTimeOrNull(dateString: String): LocalDateTime? {
         }
     }
 }
+
+internal fun isValidDateTimeFormat(dateString: String): Boolean {
+    return parseEventDateTimeOrNull(dateString) != null
+}

--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -39,6 +39,7 @@ import com.jahi.pipelinetest.domain.*
 import com.jahi.pipelinetest.viewmodel.TaskViewModel
 import com.jahi.pipelinetest.viewmodel.TaskViewModelFactory
 import com.jahi.pipelinetest.TaskOverviewScreen
+import com.jahi.pipelinetest.scheduleTaskAlarms
 
 @OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
@@ -64,6 +65,7 @@ class MainActivity : ComponentActivity() {
             taskRepository
         )
         val taskViewModel = ViewModelProvider(this, taskViewModelFactory)[TaskViewModel::class.java]
+        scheduleTaskAlarms(this, prefs.tasks)
         
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(

--- a/app/src/main/java/com/jahi/pipelinetest/Prefs.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/Prefs.kt
@@ -98,4 +98,8 @@ class Prefs(context: Context) {
             }
             prefs.edit().putString("tasks", arr.toString()).apply()
         }
+
+    var nextTaskId: Int
+        get() = prefs.getInt("nextTaskId", 1)
+        set(value) { prefs.edit().putInt("nextTaskId", value).apply() }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/SettingsScreen.kt
@@ -26,8 +26,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.ui.platform.LocalContext
-import android.app.DatePickerDialog
-import android.app.TimePickerDialog
+import com.jahi.pipelinetest.util.openDateTimePicker
 import com.jahi.pipelinetest.scheduleEventAlarms
 import com.jahi.pipelinetest.cancelEventAlarms
 import com.jahi.pipelinetest.parseEventDateTimeOrNull
@@ -297,45 +296,3 @@ private fun DarkTextField(
     )
 }
 
-private fun openDateTimePicker(
-    context: android.content.Context,
-    value: String,
-    showTime: Boolean,
-    onSelected: (String) -> Unit
-) {
-    var dateTime = run {
-        try {
-            LocalDateTime.parse(value)
-        } catch (_: Exception) {
-            try {
-                LocalDate.parse(value).atStartOfDay()
-            } catch (_: Exception) {
-                LocalDateTime.now()
-            }
-        }
-    }
-
-    DatePickerDialog(
-        context,
-        { _, year, month, day ->
-            dateTime = dateTime.withYear(year).withMonth(month + 1).withDayOfMonth(day)
-            if (showTime) {
-                TimePickerDialog(
-                    context,
-                    { _, hour, minute ->
-                        dateTime = dateTime.withHour(hour).withMinute(minute)
-                        onSelected(dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
-                    },
-                    dateTime.hour,
-                    dateTime.minute,
-                    true
-                ).show()
-            } else {
-                onSelected(dateTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE))
-            }
-        },
-        dateTime.year,
-        dateTime.monthValue - 1,
-        dateTime.dayOfMonth
-    ).show()
-}

--- a/app/src/main/java/com/jahi/pipelinetest/TaskAlarmReceiver.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/TaskAlarmReceiver.kt
@@ -1,0 +1,100 @@
+package com.jahi.pipelinetest
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+
+class TaskAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val desc = intent.getStringExtra(EXTRA_TASK_DESC) ?: return
+        val taskId = intent.getIntExtra(EXTRA_TASK_ID, DEFAULT_TASK_ID)
+        val notificationId = getNotificationId(taskId, desc)
+        if (intent.action == ACTION_DISMISS) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.cancel(notificationId)
+            return
+        }
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val wakeLock = powerManager.newWakeLock(
+            PowerManager.PARTIAL_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP,
+            "TaskAlarm:WakeLock"
+        )
+        wakeLock.acquire(30000)
+        try {
+            createChannel(context)
+            val dismissIntent = Intent(context, TaskAlarmReceiver::class.java).apply {
+            action = ACTION_DISMISS
+            putExtra(EXTRA_TASK_DESC, desc)
+            putExtra(EXTRA_TASK_ID, taskId)
+        }
+            val dismissPending = PendingIntent.getBroadcast(
+                context,
+                notificationId,
+                dismissIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            val openAppIntent = Intent(context, MainActivity::class.java)
+            val openAppPending = PendingIntent.getActivity(
+                context,
+                notificationId + 1000,
+                openAppIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(desc)
+                .setContentText(context.getString(R.string.task_alarm_triggered))
+                .setContentIntent(openAppPending)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_MAX)
+                .setCategory(NotificationCompat.CATEGORY_REMINDER)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setFullScreenIntent(openAppPending, true)
+                .addAction(0, context.getString(R.string.dismiss), dismissPending)
+                .build()
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.notify(notificationId, notification)
+        } finally {
+            if (wakeLock.isHeld) {
+                wakeLock.release()
+            }
+        }
+    }
+
+    private fun createChannel(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.task_alarm_channel_name),
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = context.getString(R.string.task_alarm_channel_description)
+                setBypassDnd(false)
+                setShowBadge(true)
+                enableVibration(true)
+                enableLights(true)
+            }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val EXTRA_TASK_DESC = "task_desc"
+        const val EXTRA_TASK_ID = "task_id"
+        const val DEFAULT_TASK_ID = -1
+        const val ACTION_DISMISS = "com.jahi.pipelinetest.ACTION_DISMISS_TASK"
+        const val CHANNEL_ID = "task_alarm"
+    }
+}
+
+private fun getNotificationId(taskId: Int, desc: String): Int {
+    return if (taskId == TaskAlarmReceiver.DEFAULT_TASK_ID) desc.hashCode() else taskId
+}

--- a/app/src/main/java/com/jahi/pipelinetest/TaskAlarmScheduler.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/TaskAlarmScheduler.kt
@@ -1,0 +1,73 @@
+package com.jahi.pipelinetest
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import com.jahi.pipelinetest.model.Task
+import java.time.ZoneId
+
+private const val MAX_TASK_ALARMS = 50
+
+internal fun scheduleTaskAlarms(context: Context, tasks: List<Task>): Int {
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    var count = 0
+    val schedulable = tasks.mapNotNull { task ->
+        val due = task.dueDate ?: return@mapNotNull null
+        val time = parseEventDateTimeOrNull(due) ?: return@mapNotNull null
+        val triggerAt = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        if (triggerAt <= System.currentTimeMillis() || task.isCompleted) return@mapNotNull null
+        task to triggerAt
+    }
+
+    if (schedulable.size > MAX_TASK_ALARMS) {
+        android.util.Log.w(
+            "TaskAlarmScheduler",
+            "Found ${schedulable.size} valid tasks for alarms, but limit is $MAX_TASK_ALARMS. Scheduling the first $MAX_TASK_ALARMS."
+        )
+    }
+
+    schedulable.take(MAX_TASK_ALARMS).forEach { (task, triggerAt) ->
+        val pending = createPendingIntentForTask(context, task)!!
+        scheduleExact(alarmManager, triggerAt, pending)
+        count++
+    }
+    return count
+}
+
+internal fun cancelTaskAlarms(context: Context, tasks: List<Task>) {
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    tasks.forEach { task ->
+        val pending = createPendingIntentForTask(context, task, PendingIntent.FLAG_NO_CREATE)
+        pending?.let { alarmManager.cancel(it) }
+    }
+}
+
+private fun createPendingIntentForTask(
+    context: Context,
+    task: Task,
+    extraFlag: Int = PendingIntent.FLAG_CANCEL_CURRENT
+): PendingIntent? {
+    val intent = Intent(context, TaskAlarmReceiver::class.java).apply {
+        putExtra(TaskAlarmReceiver.EXTRA_TASK_DESC, task.description)
+        putExtra(TaskAlarmReceiver.EXTRA_TASK_ID, task.id)
+    }
+    val flags = extraFlag or PendingIntent.FLAG_IMMUTABLE
+    return PendingIntent.getBroadcast(context, task.id, intent, flags)
+}
+
+private fun scheduleExact(alarmManager: AlarmManager, triggerAt: Long, pending: PendingIntent) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (alarmManager.canScheduleExactAlarms()) {
+            alarmManager.setAlarmClock(AlarmManager.AlarmClockInfo(triggerAt, pending), pending)
+        } else {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+        }
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+    } else {
+        alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAt, pending)
+    }
+}

--- a/app/src/main/java/com/jahi/pipelinetest/domain/AddTaskToEventUseCase.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/domain/AddTaskToEventUseCase.kt
@@ -4,11 +4,13 @@ import com.jahi.pipelinetest.model.Task
 import com.jahi.pipelinetest.repository.TaskRepository
 
 class AddTaskToEventUseCase(private val taskRepository: TaskRepository) {
-    
-    operator fun invoke(eventId: Int, description: String) {
+
+    operator fun invoke(eventId: Int, description: String, dueDate: String? = null) {
         val task = Task(
+            id = taskRepository.generateTaskId(),
             eventId = eventId,
-            description = description
+            description = description,
+            dueDate = dueDate
         )
         taskRepository.addTask(task)
     }

--- a/app/src/main/java/com/jahi/pipelinetest/model/Task.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/model/Task.kt
@@ -1,7 +1,7 @@
 package com.jahi.pipelinetest.model
 
 data class Task(
-    val id: Int = kotlin.random.Random.nextInt(),
+    val id: Int,
     val eventId: Int,
     var description: String = "",
     var isCompleted: Boolean = false,

--- a/app/src/main/java/com/jahi/pipelinetest/repository/TaskRepository.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/repository/TaskRepository.kt
@@ -7,9 +7,22 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class TaskRepository(private val prefs: Prefs) {
-    
+
     private val _tasks = MutableStateFlow(prefs.tasks)
     val tasks: Flow<List<Task>> = _tasks.asStateFlow()
+
+    init {
+        val maxId = prefs.tasks.maxOfOrNull { it.id } ?: 0
+        if (prefs.nextTaskId <= maxId) {
+            prefs.nextTaskId = maxId + 1
+        }
+    }
+
+    fun generateTaskId(): Int {
+        val id = prefs.nextTaskId
+        prefs.nextTaskId = id + 1
+        return id
+    }
     
     private fun refreshTasks() {
         _tasks.value = prefs.tasks

--- a/app/src/main/java/com/jahi/pipelinetest/ui/components/TaskList.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/ui/components/TaskList.kt
@@ -3,6 +3,7 @@ package com.jahi.pipelinetest.ui.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
@@ -11,6 +12,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -18,6 +20,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.jahi.pipelinetest.model.Task
 import com.jahi.pipelinetest.viewmodel.TaskViewModel
+import com.jahi.pipelinetest.util.openDateTimePicker
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -29,9 +32,11 @@ fun TaskList(
 ) {
     val completedTasks = tasks.count { it.isCompleted }
     val totalTasks = tasks.size
+    val context = LocalContext.current
 
     var isAdding by remember { mutableStateOf(false) }
     var newDescription by remember { mutableStateOf("") }
+    var newDueDate by remember { mutableStateOf("") }
     
     Column(modifier = modifier) {
         // Task progress header
@@ -83,6 +88,24 @@ fun TaskList(
                         label = { Text("Task description") },
                         modifier = Modifier.fillMaxWidth()
                     )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                openDateTimePicker(context, newDueDate, true) { selected ->
+                                    newDueDate = selected
+                                }
+                            }
+                    ) {
+                        OutlinedTextField(
+                            value = newDueDate,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Due Date") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -92,15 +115,23 @@ fun TaskList(
                         TextButton(onClick = {
                             isAdding = false
                             newDescription = ""
+                            newDueDate = ""
                         }) {
                             Text("Cancel")
                         }
                         TextButton(
                             onClick = {
                                 if (newDescription.isNotBlank()) {
-                                    taskViewModel.addTask(eventId, newDescription)
+                                    val due = newDueDate.takeIf { it.isNotBlank() }
+                                    taskViewModel.addTask(
+                                        context,
+                                        eventId,
+                                        newDescription,
+                                        due
+                                    )
                                     isAdding = false
                                     newDescription = ""
+                                    newDueDate = ""
                                 }
                             },
                             enabled = newDescription.isNotBlank()
@@ -129,9 +160,9 @@ fun TaskList(
                 items(tasks) { task ->
                     TaskItem(
                         task = task,
-                        onToggleCompletion = { taskViewModel.toggleTaskCompletion(task) },
-                        onDelete = { taskViewModel.deleteTask(task) },
-                        onUpdate = { updated -> taskViewModel.updateTask(updated) }
+                        onToggleCompletion = { taskViewModel.toggleTaskCompletion(context, task) },
+                        onDelete = { taskViewModel.deleteTask(context, task) },
+                        onUpdate = { updated -> taskViewModel.updateTask(context, updated) }
                     )
                 }
             }
@@ -145,7 +176,8 @@ fun TaskItem(
     onToggleCompletion: () -> Unit,
     onDelete: () -> Unit,
     onUpdate: (Task) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    context: android.content.Context = LocalContext.current
 ) {
     Card(
         modifier = modifier
@@ -160,6 +192,7 @@ fun TaskItem(
     ) {
         var isEditing by remember { mutableStateOf(false) }
         var editText by remember { mutableStateOf(task.description) }
+        var editDueDate by remember { mutableStateOf(task.dueDate ?: "") }
 
         Row(
             modifier = Modifier
@@ -173,17 +206,45 @@ fun TaskItem(
             )
 
             if (isEditing) {
-                OutlinedTextField(
-                    value = editText,
-                    onValueChange = { editText = it },
+                Column(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 8.dp),
-                    singleLine = true
-                )
+                        .padding(horizontal = 8.dp)
+                ) {
+                    OutlinedTextField(
+                        value = editText,
+                        onValueChange = { editText = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                openDateTimePicker(context, editDueDate, true) { selected ->
+                                    editDueDate = selected
+                                }
+                            }
+                    ) {
+                        OutlinedTextField(
+                            value = editDueDate,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Due Date") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
                 IconButton(
                     onClick = {
-                        onUpdate(task.copy(description = editText))
+                        val due = editDueDate.takeIf { it.isNotBlank() }
+                        onUpdate(
+                            task.copy(
+                                description = editText,
+                                dueDate = due
+                            )
+                        )
                         isEditing = false
                     }
                 ) {
@@ -193,6 +254,7 @@ fun TaskItem(
                     onClick = {
                         isEditing = false
                         editText = task.description
+                        editDueDate = task.dueDate ?: ""
                     }
                 ) {
                     Icon(Icons.Default.Close, contentDescription = "Cancel edit")
@@ -209,9 +271,18 @@ fun TaskItem(
                     else
                         MaterialTheme.colorScheme.onSurface
                 )
+                task.dueDate?.let { due ->
+                    Text(
+                        text = due,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                }
                 IconButton(
                     onClick = {
                         editText = task.description
+                        editDueDate = task.dueDate ?: ""
                         isEditing = true
                     }
                 ) {

--- a/app/src/main/java/com/jahi/pipelinetest/util/DateTimePickerUtil.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/util/DateTimePickerUtil.kt
@@ -1,0 +1,51 @@
+package com.jahi.pipelinetest.util
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Context
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+fun openDateTimePicker(
+    context: Context,
+    value: String,
+    showTime: Boolean,
+    onSelected: (String) -> Unit
+) {
+    var dateTime = run {
+        try {
+            LocalDateTime.parse(value)
+        } catch (_: Exception) {
+            try {
+                LocalDate.parse(value).atStartOfDay()
+            } catch (_: Exception) {
+                LocalDateTime.now()
+            }
+        }
+    }
+
+    DatePickerDialog(
+        context,
+        { _, year, month, day ->
+            dateTime = dateTime.withYear(year).withMonth(month + 1).withDayOfMonth(day)
+            if (showTime) {
+                TimePickerDialog(
+                    context,
+                    { _, hour, minute ->
+                        dateTime = dateTime.withHour(hour).withMinute(minute)
+                        onSelected(dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                    },
+                    dateTime.hour,
+                    dateTime.minute,
+                    true
+                ).show()
+            } else {
+                onSelected(dateTime.toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE))
+            }
+        },
+        dateTime.year,
+        dateTime.monthValue - 1,
+        dateTime.dayOfMonth
+    ).show()
+}

--- a/app/src/main/java/com/jahi/pipelinetest/viewmodel/TaskViewModel.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/viewmodel/TaskViewModel.kt
@@ -4,8 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.jahi.pipelinetest.domain.*
+import android.content.Context
 import com.jahi.pipelinetest.model.Task
 import com.jahi.pipelinetest.repository.TaskRepository
+import com.jahi.pipelinetest.scheduleTaskAlarms
+import com.jahi.pipelinetest.cancelTaskAlarms
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,37 +33,47 @@ class TaskViewModel(
         taskRepository.tasks
             .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
+    private suspend fun rescheduleAlarms(context: Context) {
+        val tasks = taskRepository.tasks.first()
+        cancelTaskAlarms(context, tasks)
+        scheduleTaskAlarms(context, tasks)
+    }
+
     fun loadTasksForEvent(eventId: Int) {
         viewModelScope.launch {
             _tasks.value = getTasksForEventUseCase(eventId)
         }
     }
 
-    fun addTask(eventId: Int, description: String) {
+    fun addTask(context: Context, eventId: Int, description: String, dueDate: String?) {
         viewModelScope.launch {
-            addTaskToEventUseCase(eventId, description)
+            addTaskToEventUseCase(eventId, description, dueDate)
             loadTasksForEvent(eventId)
+            rescheduleAlarms(context)
         }
     }
 
-    fun updateTask(task: Task) {
+    fun updateTask(context: Context, task: Task) {
         viewModelScope.launch {
             updateTaskUseCase(task)
             loadTasksForEvent(task.eventId)
+            rescheduleAlarms(context)
         }
     }
 
-    fun deleteTask(task: Task) {
+    fun deleteTask(context: Context, task: Task) {
         viewModelScope.launch {
             deleteTaskUseCase(task.id)
             loadTasksForEvent(task.eventId)
+            rescheduleAlarms(context)
         }
     }
 
-    fun toggleTaskCompletion(task: Task) {
+    fun toggleTaskCompletion(context: Context, task: Task) {
         viewModelScope.launch {
             toggleTaskCompletionUseCase(task.id)
             loadTasksForEvent(task.eventId)
+            rescheduleAlarms(context)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,9 @@
     <string name="event_alarm_channel_name">Event Alarms</string>
     <string name="event_alarm_channel_description">Notifications for scheduled events</string>
     <string name="event_alarm_triggered">Event time reached</string>
+    <string name="task_alarm_channel_name">Task Reminders</string>
+    <string name="task_alarm_channel_description">Notifications for task deadlines</string>
+    <string name="task_alarm_triggered">Task deadline reached</string>
     <string name="dismiss">Dismiss</string>
     <string name="events_scheduled">Event alarms scheduled</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow tasks to include a deadline using a shared date/time picker
- schedule/cancel task alarms with `TaskAlarmReceiver`
- show and edit due dates in `TaskList`
- reschedule alarms through `TaskViewModel`
- register receiver and notification strings
- refine alarm scheduling logic and UI after review

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_683e2718c50c832a839c79b4336ea04e