### PR TITLE
Add LLM model repository with caching

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/CircularProgressWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/CircularProgressWidget.kt
@@ -17,6 +17,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.jahi.pipelinetest.domain.GenerateAudioUseCase
 import com.jahi.pipelinetest.domain.GenerateMotivationalTextUseCase
+import com.jahi.pipelinetest.domain.GetInitializedLlmModelUseCase
 import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import java.time.Duration
 import java.time.LocalDateTime
@@ -57,19 +58,14 @@ class CircularProgressWidget : AppWidgetProvider() {
                 onUpdate(context, appWidgetManager, appWidgetIds)
             }
             ACTION_GENERATE_AUDIO -> {
-                // Get the app container to access AI models
                 val application = context.applicationContext as? com.jahi.pipelinetest.gallery.GalleryApplication
-                val appContainer = application?.container
-                
-                // Create the use cases
-                val generateMotivationalTextUseCase = if (appContainer != null) {
-                    GenerateMotivationalTextUseCase(context, appContainer)
-                } else {
-                    // Create a stub AppContainer for fallback
+                val container = application?.container ?: run {
                     val dataStore = context.dataStore
-                    val stubContainer = com.jahi.pipelinetest.gallery.data.DefaultAppContainer(context, dataStore)
-                    GenerateMotivationalTextUseCase(context, stubContainer)
+                    com.jahi.pipelinetest.gallery.data.DefaultAppContainer(context, dataStore)
                 }
+
+                val getModelUseCase = GetInitializedLlmModelUseCase(context, container.llmModelRepository)
+                val generateMotivationalTextUseCase = GenerateMotivationalTextUseCase(context, getModelUseCase)
                 
                 val generateAudioUseCase = GenerateAudioUseCase(context, generateMotivationalTextUseCase)
                 val vm = WidgetViewModel(generateAudioUseCase)

--- a/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/DailyCountdownWidget.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.jahi.pipelinetest.domain.GenerateAudioUseCase
 import com.jahi.pipelinetest.domain.GenerateMotivationalTextUseCase
+import com.jahi.pipelinetest.domain.GetInitializedLlmModelUseCase
 import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import java.time.Duration
 import java.time.Instant
@@ -56,20 +57,14 @@ class DailyCountdownWidget : AppWidgetProvider() {
             }
             scheduleUpdates(context)
         } else if (intent.action == ACTION_GENERATE_AUDIO) {
-            // Get the app container to access AI models
             val application = context.applicationContext as? com.jahi.pipelinetest.gallery.GalleryApplication
-            val appContainer = application?.container
-            
-            // Create the use cases
-            val generateMotivationalTextUseCase = if (appContainer != null) {
-                GenerateMotivationalTextUseCase(context, appContainer)
-            } else {
-                // Create a stub AppContainer for fallback
-                // We'll use a minimal container that won't have any downloaded models
+            val container = application?.container ?: run {
                 val dataStore = context.dataStore
-                val stubContainer = com.jahi.pipelinetest.gallery.data.DefaultAppContainer(context, dataStore)
-                GenerateMotivationalTextUseCase(context, stubContainer)
+                com.jahi.pipelinetest.gallery.data.DefaultAppContainer(context, dataStore)
             }
+
+            val getModelUseCase = GetInitializedLlmModelUseCase(context, container.llmModelRepository)
+            val generateMotivationalTextUseCase = GenerateMotivationalTextUseCase(context, getModelUseCase)
             
             val generateAudioUseCase = GenerateAudioUseCase(context, generateMotivationalTextUseCase)
             val vm = WidgetViewModel(generateAudioUseCase)

--- a/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/EventCountdownWidget.kt
@@ -17,6 +17,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.jahi.pipelinetest.domain.GenerateAudioUseCase
 import com.jahi.pipelinetest.domain.GenerateMotivationalTextUseCase
+import com.jahi.pipelinetest.domain.GetInitializedLlmModelUseCase
 import com.jahi.pipelinetest.viewmodel.WidgetViewModel
 import com.jahi.pipelinetest.model.CustomEvent
 import java.time.Duration
@@ -62,19 +63,14 @@ class EventCountdownWidget : AppWidgetProvider() {
                 onUpdate(context, appWidgetManager, appWidgetIds)
             }
             ACTION_GENERATE_AUDIO -> {
-                // Get the app container to access AI models
                 val application = context.applicationContext as? com.jahi.pipelinetest.gallery.GalleryApplication
-                val appContainer = application?.container
-                
-                // Create the use cases
-                val generateMotivationalTextUseCase = if (appContainer != null) {
-                    GenerateMotivationalTextUseCase(context, appContainer)
-                } else {
-                    // Create a stub AppContainer for fallback
+                val container = application?.container ?: run {
                     val dataStore = context.dataStore
-                    val stubContainer = com.jahi.pipelinetest.gallery.data.DefaultAppContainer(context, dataStore)
-                    GenerateMotivationalTextUseCase(context, stubContainer)
+                    com.jahi.pipelinetest.gallery.data.DefaultAppContainer(context, dataStore)
                 }
+
+                val getModelUseCase = GetInitializedLlmModelUseCase(context, container.llmModelRepository)
+                val generateMotivationalTextUseCase = GenerateMotivationalTextUseCase(context, getModelUseCase)
                 
                 val generateAudioUseCase = GenerateAudioUseCase(context, generateMotivationalTextUseCase)
                 val vm = WidgetViewModel(generateAudioUseCase)

--- a/app/src/main/java/com/jahi/pipelinetest/domain/GenerateMotivationalTextUseCase.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/domain/GenerateMotivationalTextUseCase.kt
@@ -2,23 +2,21 @@ package com.jahi.pipelinetest.domain
 
 import android.content.Context
 import android.util.Log
-import com.jahi.pipelinetest.gallery.data.AppContainer
 import com.jahi.pipelinetest.gallery.data.Model
 import com.jahi.pipelinetest.gallery.ui.llmchat.LlmChatModelHelper
+import com.jahi.pipelinetest.domain.GetInitializedLlmModelUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import java.io.File
 import kotlin.coroutines.resume
 
 class GenerateMotivationalTextUseCase(
     private val context: Context,
-    @Suppress("unused") private val appContainer: AppContainer
+    private val getInitializedLlmModelUseCase: GetInitializedLlmModelUseCase
 ) {
     companion object {
         private const val TAG = "GenerateMotivationalText"
-        private const val INITIALIZATION_TIMEOUT_MS = 120_000L // 2 minutes for initialization
         private const val GENERATION_TIMEOUT_MS = 30_000L // 30 seconds for generation
     }
 
@@ -47,8 +45,8 @@ class GenerateMotivationalTextUseCase(
 
     suspend operator fun invoke(): String = withContext(Dispatchers.IO) {
         try {
-            // Try to find and use a downloaded LLM model
-            val llmModel = findDownloadedLlmModel()
+            // Obtain an initialized LLM model from the repository
+            val llmModel = getInitializedLlmModelUseCase()
             
             if (llmModel != null) {
                 Log.d(TAG, "Found LLM model: ${llmModel.name}")
@@ -71,125 +69,10 @@ class GenerateMotivationalTextUseCase(
         return@withContext fallbackSentences.random()
     }
 
-    private fun findDownloadedLlmModel(): Model? {
-        val externalDir = context.getExternalFilesDir(null)
-        if (externalDir != null) {
-            Log.d(TAG, "External files dir: ${externalDir.absolutePath}")
-            
-            // List all directories to see what's there
-            val directories = externalDir.listFiles { file -> file.isDirectory }
-            directories?.forEach { dir ->
-                Log.d(TAG, "Found directory: ${dir.name}")
-            }
-            
-            // Check __imports directory (note the double underscore)
-            val importsDir = File(externalDir, "__imports")
-            Log.d(TAG, "Checking __imports directory: ${importsDir.absolutePath}, exists: ${importsDir.exists()}")
-            
-            if (importsDir.exists()) {
-                val files = importsDir.listFiles()
-                Log.d(TAG, "Found ${files?.size ?: 0} files in __imports")
-                
-                files?.forEach { file ->
-                    Log.d(TAG, "Found file: ${file.name}, size: ${file.length() / 1024 / 1024}MB")
-                    
-                    // Check for .task or .bin files that look like LLM models
-                    if ((file.name.endsWith(".task") || file.name.endsWith(".bin")) && 
-                        file.length() > 10_000_000) { // At least 10MB
-                        
-                        // Create a model for this file
-                        val model = Model(
-                            name = file.nameWithoutExtension,
-                            downloadFileName = "__imports/${file.name}", // Include __imports in the path
-                            sizeInBytes = file.length(),
-                            version = "imported",
-                            url = "",
-                            imported = true
-                        )
-                        model.preProcess()
-                        
-                        Log.d(TAG, "Created imported model: ${model.name}")
-                        Log.d(TAG, "Model path will be: ${model.getPath(context)}")
-                        return model
-                    }
-                }
-            }
-            
-            // Also check for any downloaded models in versioned directories
-            val modelDirs = externalDir.listFiles { file -> 
-                file.isDirectory && !file.name.startsWith("__")
-            }
-            
-            modelDirs?.forEach { modelDir ->
-                Log.d(TAG, "Checking model directory: ${modelDir.name}")
-                
-                // Look for version directories inside
-                val versionDirs = modelDir.listFiles { file -> file.isDirectory }
-                versionDirs?.forEach { versionDir ->
-                    Log.d(TAG, "Checking version directory: ${versionDir.name}")
-                    
-                    // Look for model files
-                    val modelFiles = versionDir.listFiles { file ->
-                        file.name.endsWith(".task") || file.name.endsWith(".bin")
-                    }
-                    
-                    modelFiles?.forEach { modelFile ->
-                        Log.d(TAG, "Found model file: ${modelFile.name} in ${modelDir.name}/${versionDir.name}")
-                        
-                        if (modelFile.length() > 10_000_000) { // At least 10MB
-                            val model = Model(
-                                name = modelDir.name,
-                                downloadFileName = modelFile.name,
-                                sizeInBytes = modelFile.length(),
-                                version = versionDir.name,
-                                url = "",
-                                imported = false
-                            )
-                            model.preProcess()
-                            
-                            Log.d(TAG, "Created model from directory: ${model.name}")
-                            return model
-                        }
-                    }
-                }
-            }
-        }
-        
-        Log.d(TAG, "No LLM model found in any location")
-        return null
-    }
 
     private suspend fun generateWithAI(model: Model): String? {
         try {
-            // Initialize the model if needed
-            if (model.instance == null) {
-                Log.d(TAG, "Initializing model ${model.name}")
-                
-                val initResult = withTimeoutOrNull(INITIALIZATION_TIMEOUT_MS) {
-                    suspendCancellableCoroutine { continuation ->
-                        LlmChatModelHelper.initialize(
-                            context = context,
-                            model = model,
-                            onDone = { error ->
-                                if (error.isNotEmpty()) {
-                                    Log.e(TAG, "Failed to initialize model: $error")
-                                    continuation.resume(false)
-                                } else {
-                                    Log.d(TAG, "Model initialized successfully")
-                                    continuation.resume(true)
-                                }
-                            }
-                        )
-                    }
-                }
-                
-                if (initResult != true) {
-                    Log.e(TAG, "Model initialization failed or timed out")
-                    return null
-                }
-            }
-            
-            // Now generate text with timeout
+            // Generate text with timeout using the already initialized model
             return withTimeoutOrNull(GENERATION_TIMEOUT_MS) {
                 suspendCancellableCoroutine { continuation ->
                     generateTextWithInitializedModel(model, continuation)

--- a/app/src/main/java/com/jahi/pipelinetest/domain/GetInitializedLlmModelUseCase.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/domain/GetInitializedLlmModelUseCase.kt
@@ -1,0 +1,12 @@
+package com.jahi.pipelinetest.domain
+
+import android.content.Context
+import com.jahi.pipelinetest.gallery.data.Model
+import com.jahi.pipelinetest.repository.LlmModelRepository
+
+class GetInitializedLlmModelUseCase(
+    private val context: Context,
+    private val repository: LlmModelRepository
+) {
+    suspend operator fun invoke(): Model? = repository.getInitializedModel(context)
+}

--- a/app/src/main/java/com/jahi/pipelinetest/gallery/GalleryApplication.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/GalleryApplication.kt
@@ -25,6 +25,10 @@ import com.jahi.pipelinetest.gallery.data.AppContainer
 import com.jahi.pipelinetest.gallery.data.DefaultAppContainer
 import com.jahi.pipelinetest.gallery.ui.common.writeLaunchInfo
 import com.jahi.pipelinetest.gallery.ui.theme.ThemeSettings
+import com.jahi.pipelinetest.domain.GetInitializedLlmModelUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_gallery_preferences")
 
@@ -41,5 +45,10 @@ class GalleryApplication : Application() {
 
     // Load theme.
     ThemeSettings.themeOverride.value = container.dataStoreRepository.readThemeOverride()
+
+    // Warm up LLM model cache
+    CoroutineScope(Dispatchers.IO).launch {
+      GetInitializedLlmModelUseCase(this@GalleryApplication, container.llmModelRepository)()
+    }
   }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/gallery/data/AppContainer.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/data/AppContainer.kt
@@ -21,6 +21,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.jahi.pipelinetest.gallery.GalleryLifecycleProvider
 import com.jahi.pipelinetest.gallery.AppLifecycleProvider
+import com.jahi.pipelinetest.repository.LlmModelRepository
 
 /**
  * App container for Dependency injection.
@@ -32,6 +33,7 @@ interface AppContainer {
   val lifecycleProvider: AppLifecycleProvider
   val dataStoreRepository: DataStoreRepository
   val downloadRepository: DownloadRepository
+  val llmModelRepository: LlmModelRepository
 }
 
 /**
@@ -44,4 +46,5 @@ class DefaultAppContainer(ctx: Context, dataStore: DataStore<Preferences>) : App
   override val lifecycleProvider = GalleryLifecycleProvider()
   override val dataStoreRepository = DefaultDataStoreRepository(dataStore)
   override val downloadRepository = DefaultDownloadRepository(ctx, lifecycleProvider)
+  override val llmModelRepository = LlmModelRepository()
 }

--- a/app/src/main/java/com/jahi/pipelinetest/repository/LlmModelRepository.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/repository/LlmModelRepository.kt
@@ -1,0 +1,106 @@
+package com.jahi.pipelinetest.repository
+
+import android.content.Context
+import android.util.Log
+import com.jahi.pipelinetest.gallery.data.Model
+import com.jahi.pipelinetest.gallery.ui.llmchat.LlmChatModelHelper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
+import kotlin.coroutines.resume
+
+class LlmModelRepository {
+    companion object {
+        private const val TAG = "LlmModelRepository"
+        private const val MIN_MODEL_SIZE_BYTES = 10_000_000L
+        private const val INITIALIZATION_TIMEOUT_MS = 120_000L
+    }
+
+    private var cachedModel: Model? = null
+
+    suspend fun getInitializedModel(context: Context): Model? = withContext(Dispatchers.IO) {
+        cachedModel?.let { model ->
+            if (model.instance != null) {
+                return@withContext model
+            }
+        }
+
+        val model = findDownloadedLlmModel(context) ?: return@withContext null
+
+        if (model.instance == null) {
+            val success = withTimeoutOrNull(INITIALIZATION_TIMEOUT_MS) {
+                suspendCancellableCoroutine<Boolean> { cont ->
+                    LlmChatModelHelper.initialize(
+                        context = context,
+                        model = model,
+                        onDone = { error ->
+                            cont.resume(error.isEmpty())
+                        }
+                    )
+                }
+            } == true
+
+            if (!success) {
+                Log.e(TAG, "Failed to initialize model")
+                return@withContext null
+            }
+        }
+
+        cachedModel = model
+        return@withContext model
+    }
+
+    private fun findDownloadedLlmModel(context: Context): Model? {
+        val externalDir = context.getExternalFilesDir(null) ?: return null
+        Log.d(TAG, "External files dir: ${'$'}{externalDir.absolutePath}")
+
+        val importsDir = File(externalDir, "__imports")
+        if (importsDir.exists()) {
+            importsDir.listFiles()?.forEach { file ->
+                if ((file.name.endsWith(".task") || file.name.endsWith(".bin")) &&
+                    file.length() > MIN_MODEL_SIZE_BYTES
+                ) {
+                    val model = Model(
+                        name = file.nameWithoutExtension,
+                        downloadFileName = "__imports/${'$'}{file.name}",
+                        sizeInBytes = file.length(),
+                        version = "imported",
+                        url = "",
+                        imported = true
+                    )
+                    model.preProcess()
+                    return model
+                }
+            }
+        }
+
+        val modelDirs = externalDir.listFiles { f -> f.isDirectory && !f.name.startsWith("__") }
+        modelDirs?.forEach { modelDir ->
+            val versionDirs = modelDir.listFiles { f -> f.isDirectory }
+            versionDirs?.forEach { versionDir ->
+                val modelFiles = versionDir.listFiles { f ->
+                    f.name.endsWith(".task") || f.name.endsWith(".bin")
+                }
+                modelFiles?.forEach { modelFile ->
+                    if (modelFile.length() > MIN_MODEL_SIZE_BYTES) {
+                        val model = Model(
+                            name = modelDir.name,
+                            downloadFileName = modelFile.name,
+                            sizeInBytes = modelFile.length(),
+                            version = versionDir.name,
+                            url = "",
+                            imported = false
+                        )
+                        model.preProcess()
+                        return model
+                    }
+                }
+            }
+        }
+
+        Log.d(TAG, "No LLM model found in any location")
+        return null
+    }
+}

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -65,7 +65,11 @@
    - **COMPLETE**: Used few-shot prompting with examples to guide AI toward concise responses
    - **COMPLETE**: Support for both imported models and downloaded models from Gallery allowlist
    - **COMMITTED**: Feature committed to feature/ai-gallery-integration branch (commit 495e34e)
-   - **TESTED**: AI model initialization, text generation, and TTS working with downloaded models
+    - **TESTED**: AI model initialization, text generation, and TTS working with downloaded models
+9. **Added LLM model repository with caching**:
+   - Created `LlmModelRepository` for shared model initialization
+   - Added `GetInitializedLlmModelUseCase` and integrated into widgets
+   - Preloaded model in `GalleryApplication` to avoid delay
 
 ## Current Focus
 - **LOGGING STANDARDIZATION**: Implement Timber logging with DEBUG_FLOW tag and class prefixes across all components

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -47,6 +47,7 @@
 - ✅ **JSON escaping** for TTS compatibility
 - ✅ **Comprehensive logging** with DEBUG_FLOW tags
 - ✅ **Error handling** with timeouts and recovery
+- ✅ **Model caching** with shared repository
 
 ### Gallery Integration
 - ✅ **Google AI Edge Gallery components** (8 core UI components)


### PR DESCRIPTION
## Summary
- cache initialized LLM models in new `LlmModelRepository`
- provide `GetInitializedLlmModelUseCase` for domain layer
- preload LLM model on app startup
- update widgets to use cached model
- document new repository in memory bank

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_683f70e26bac832aa7bee5fd8ffb2114