### PR TITLE
Reorder tabs

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -137,24 +137,11 @@ class MainActivity : ComponentActivity() {
                             )
                         },
                         bottomBar = {
-                            NavigationBar(containerColor = com.jahi.pipelinetest.ui.theme.SurfaceDark.copy(alpha = 0.8f)) {
+                                NavigationBar(containerColor = com.jahi.pipelinetest.ui.theme.SurfaceDark.copy(alpha = 0.8f)) {
                                 NavigationBarItem(
                                     selected = viewModel.screen == SCREEN_COUNTDOWNS,
                                     onClick = { viewModel.selectScreen(SCREEN_COUNTDOWNS) },
                                     label = { Text(NAV_LABEL_COUNTDOWNS) },
-                                    icon = { },
-                                    colors = NavigationBarItemDefaults.colors(
-                                        selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
-                                        selectedTextColor = com.jahi.pipelinetest.ui.theme.Slate100,
-                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate400,
-                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate400,
-                                        indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
-                                    )
-                                )
-                                NavigationBarItem(
-                                    selected = viewModel.screen == SCREEN_LIFE,
-                                    onClick = { viewModel.selectScreen(SCREEN_LIFE) },
-                                    label = { Text(NAV_LABEL_LIFE) },
                                     icon = { },
                                     colors = NavigationBarItemDefaults.colors(
                                         selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
@@ -190,13 +177,26 @@ class MainActivity : ComponentActivity() {
                                         indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
                                     )
                                 )
+                                NavigationBarItem(
+                                    selected = viewModel.screen == SCREEN_LIFE,
+                                    onClick = { viewModel.selectScreen(SCREEN_LIFE) },
+                                    label = { Text(NAV_LABEL_LIFE) },
+                                    icon = { },
+                                    colors = NavigationBarItemDefaults.colors(
+                                        selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
+                                        selectedTextColor = com.jahi.pipelinetest.ui.theme.Slate100,
+                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
+                                    )
+                                )
                             }
                         }
                     ) { innerPadding ->
                         when (viewModel.screen) {
                             SCREEN_COUNTDOWNS -> CountdownsScreen(viewModel, taskViewModel, Modifier.padding(innerPadding))
-                            SCREEN_LIFE -> LifeHourglassScreen(viewModel, Modifier.padding(innerPadding))
                             SCREEN_TASKS -> TaskOverviewScreen(viewModel, taskViewModel, Modifier.padding(innerPadding))
+                            SCREEN_LIFE -> LifeHourglassScreen(viewModel, Modifier.padding(innerPadding))
                             else -> CountdownsScreen(viewModel, taskViewModel, Modifier.padding(innerPadding))
                         }
                     }
@@ -228,9 +228,9 @@ class MainActivity : ComponentActivity() {
         
         // Screen indices
         private const val SCREEN_COUNTDOWNS = 0
-        private const val SCREEN_LIFE = 1
-        private const val SCREEN_TASKS = 2
-        private const val SCREEN_GALLERY = 3
+        private const val SCREEN_TASKS = 1
+        private const val SCREEN_GALLERY = 2
+        private const val SCREEN_LIFE = 3
         
         // Navigation labels
         private const val NAV_LABEL_COUNTDOWNS = "Countdowns"

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -15,7 +15,11 @@
    - **BUILD VERIFIED**: All builds successful, navigation working correctly
    - **USER EXPERIENCE**: Resolves issue where back button would exit entire app from AI Gallery
 
-2. **Implemented Complete AI Gallery Fullscreen Experience**:
+2. **Reordered Navigation Tabs**:
+   - Life tab moved to last position
+   - New order: Countdowns, Tasks, AI Gallery, Life
+
+3. **Implemented Complete AI Gallery Fullscreen Experience**:
    - **FULLSCREEN MODE**: AI Gallery now displays without Time Fomo app bars when selected
    - **ORIGINAL UI RESTORED**: Completely replaced GalleryScreen with original Google AI Edge Gallery HomeScreen
    - **SOLUTION APPLIED**:
@@ -89,7 +93,7 @@
    - Added new navigation item "AI Gallery" to bottom navigation bar  
    - Updated MainActivity.kt to use constants for all screen indices and labels
    - Replaced hardcoded strings with constants following Memory Bank standards
-   - Added screen routing for Gallery screen (index 3)
+   - Added screen routing for Gallery screen (index 2)
    - Built dependency structure for Gallery app (navigation, serialization, icons, etc.)
    - Created interactive feature cards showing AI capabilities:
      * LLM Chat (marked as available)

--- a/memory-bank/aiFeatures.md
+++ b/memory-bank/aiFeatures.md
@@ -9,7 +9,7 @@ Time Fomo integrates Google AI Edge Gallery capabilities to provide on-device AI
 - **Source**: Google AI Edge Gallery (https://github.com/google-ai-edge/gallery)
 - **Integration**: Selective component copying with package name updates
 - **Location**: `app/src/main/java/com/jahi/pipelinetest/gallery/`
-- **Navigation**: Added as 4th tab in bottom navigation (index 3)
+- **Navigation**: Added as 3rd tab in bottom navigation (index 2)
 
 ### UI Components
 - **GalleryScreen.kt**: Main showcase interface with feature cards

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -57,8 +57,9 @@
 - ✅ **Google AI Edge Gallery components** (8 core UI components)
 - ✅ **Package namespace updates** (com.jahi.pipelinetest.gallery)
 - ✅ **Resource integration** (fonts, drawables, strings)
-- ✅ **Navigation integration** (4th tab in bottom nav)
+- ✅ **Navigation integration** (3rd tab in bottom nav)
 - ✅ **Feature status display** (available vs coming soon)
+- ✅ **Life tab moved to last position** (updated order)
 
 ## What's Left to Build 🚧
 

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -46,7 +46,7 @@ This is NOT optional - this is the REQUIRED architecture for ALL features.
 - SharedPreferences for persistence
 
 ### Navigation
-- Bottom navigation with 3 tabs (Countdowns, Life, Tasks)
+- Bottom navigation with 4 tabs (Countdowns, Tasks, AI Gallery, Life)
 - Single Activity architecture
 - Screen state managed by MainViewModel
 


### PR DESCRIPTION
## Summary
- reorder bottom navigation to place Life tab last
- update screen indices accordingly
- adjust Memory Bank documentation for new tab order

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_684132cd6058832a90f1b6c78487fed1