### PR TITLE
Remove hardcoded UI constants

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/ChatPanel.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/ChatPanel.kt
@@ -147,6 +147,7 @@ fun ChatPanel(
   val density = LocalDensity.current
   var showBenchmarkConfigsDialog by remember { mutableStateOf(false) }
   val benchmarkMessage: MutableState<ChatMessage?> = remember { mutableStateOf(null) }
+  val context = LocalContext.current
 
   var showMessageLongPressedSheet by remember { mutableStateOf(false) }
   val longPressedMessage: MutableState<ChatMessage?> = remember { mutableStateOf(null) }
@@ -232,20 +233,20 @@ fun ChatPanel(
           var hAlign: Alignment.Horizontal = Alignment.End
           var backgroundColor: Color = MaterialTheme.customColors.userBubbleBgColor
           var hardCornerAtLeftOrRight = false
-          var extraPaddingStart = 48.dp
+          var extraPaddingStart = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_chat_extra_large)
           var extraPaddingEnd = 0.dp
           if (message.side == ChatSide.AGENT) {
             hAlign = Alignment.Start
             backgroundColor = MaterialTheme.customColors.agentBubbleBgColor
             hardCornerAtLeftOrRight = true
             extraPaddingStart = 0.dp
-            extraPaddingEnd = 48.dp
+            extraPaddingEnd = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_chat_extra_large)
           } else if (message.side == ChatSide.SYSTEM) {
-            extraPaddingStart = 24.dp
-            extraPaddingEnd = 24.dp
+            extraPaddingStart = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_chat_large)
+            extraPaddingEnd = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_chat_large)
             if (message.type == ChatMessageType.PROMPT_TEMPLATES) {
-              extraPaddingStart = 12.dp
-              extraPaddingEnd = 12.dp
+              extraPaddingStart = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_chat_medium)
+              extraPaddingEnd = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_chat_medium)
             }
           }
           if (message.type == ChatMessageType.IMAGE) {
@@ -257,10 +258,10 @@ fun ChatPanel(
             modifier = Modifier
               .fillMaxWidth()
               .padding(
-                start = 12.dp + extraPaddingStart,
-                end = 12.dp + extraPaddingEnd,
-                top = 6.dp,
-                bottom = 6.dp,
+                start = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_regular) + extraPaddingStart,
+                end = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_regular) + extraPaddingEnd,
+                top = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny),
+                bottom = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny),
               ),
             horizontalAlignment = hAlign,
           ) messageColumn@{
@@ -365,7 +366,7 @@ fun ChatPanel(
                 if (message.side == ChatSide.AGENT) {
                   Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small)),
                   ) {
                     LatencyText(message = message)
                     // A button to show stats for the LLM message.
@@ -414,7 +415,7 @@ fun ChatPanel(
                 } else if (message.side == ChatSide.USER) {
                   Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_xsmall))
                   ) {
                     // Run again button.
                     if (selectedModel.showRunAgainButton) {
@@ -448,13 +449,16 @@ fun ChatPanel(
         }
       }
 
-      SnackbarHost(hostState = snackbarHostState, modifier = Modifier.padding(vertical = 4.dp))
+      SnackbarHost(
+        hostState = snackbarHostState,
+        modifier = Modifier.padding(vertical = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_xsmall))
+      )
 
       // Show an info message for ask image task to get users started.
       if (task.type == TaskType.LLM_ASK_IMAGE && messages.isEmpty()) {
         Column(
           modifier = Modifier
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_default))
             .fillMaxSize(),
           horizontalAlignment = Alignment.CenterHorizontally,
           verticalArrangement = Arrangement.Center
@@ -567,18 +571,23 @@ fun ChatPanel(
 
               // Show a snack bar.
               scope.launch {
-                snackbarHostState.showSnackbar("Text copied to clipboard")
+                snackbarHostState.showSnackbar(context.getString(com.jahi.pipelinetest.R.string.text_copied))
               }
             }) {
             Row(
               verticalAlignment = Alignment.CenterVertically,
-              horizontalArrangement = Arrangement.spacedBy(6.dp),
-              modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)
+              horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny)),
+              modifier = Modifier.padding(
+                vertical = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small),
+                horizontal = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_default)
+              )
             ) {
               Icon(
-                Icons.Rounded.ContentCopy, contentDescription = "", modifier = Modifier.size(18.dp)
+                Icons.Rounded.ContentCopy,
+                contentDescription = "",
+                modifier = Modifier.size(dimensionResource(com.jahi.pipelinetest.R.dimen.icon_size_small))
               )
-              Text("Copy text")
+              Text(stringResource(com.jahi.pipelinetest.R.string.copy_text))
             }
           }
         }

--- a/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/ConfigDialog.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/ConfigDialog.kt
@@ -62,7 +62,8 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.window.Dialog
 import com.jahi.pipelinetest.gallery.data.BooleanSwitchConfig
 import com.jahi.pipelinetest.gallery.data.Config
@@ -108,17 +109,18 @@ fun ConfigDialog(
         ) {
           focusManager.clearFocus()
         },
-      shape = RoundedCornerShape(16.dp)
+      shape = RoundedCornerShape(dimensionResource(com.jahi.pipelinetest.R.dimen.dialog_corner_radius))
     ) {
       Column(
-        modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = Modifier.padding(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_medium)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_default))
       ) {
         // Dialog title and subtitle.
         Column {
           Text(
             title,
             style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.padding(bottom = 8.dp)
+            modifier = Modifier.padding(bottom = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small))
           )
           // Subtitle.
           if (subtitle.isNotEmpty()) {
@@ -126,7 +128,7 @@ fun ConfigDialog(
               subtitle,
               style = labelSmallNarrow,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
-              modifier = Modifier.offset(y = (-6).dp)
+              modifier = Modifier.offset(y = (-dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny)))
             )
           }
         }
@@ -136,7 +138,7 @@ fun ConfigDialog(
           modifier = Modifier
             .verticalScroll(rememberScrollState())
             .weight(1f, fill = false),
-          verticalArrangement = Arrangement.spacedBy(16.dp)
+          verticalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_default))
         ) {
           ConfigEditorsPanel(configs = configs, values = values)
         }
@@ -145,7 +147,7 @@ fun ConfigDialog(
         Row(
           modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 8.dp),
+            .padding(top = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small)),
           horizontalArrangement = Arrangement.End,
         ) {
           // Cancel button.
@@ -153,7 +155,7 @@ fun ConfigDialog(
             TextButton(
               onClick = { onDismissed() },
             ) {
-              Text("Cancel")
+              Text(stringResource(com.jahi.pipelinetest.R.string.cancel))
             }
           }
 
@@ -246,13 +248,13 @@ fun NumberSliderRow(config: NumberSliderConfig, values: SnapshotStateMap<String,
         0f
       }
       Slider(modifier = Modifier
-        .height(24.dp)
+        .height(dimensionResource(com.jahi.pipelinetest.R.dimen.slider_height_small))
         .weight(1f),
         value = sliderValue,
         valueRange = config.sliderMin..config.sliderMax,
         onValueChange = { values[config.key.label] = it })
 
-      Spacer(modifier = Modifier.width(8.dp))
+      Spacer(modifier = Modifier.width(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small)))
 
       // Text field.
       val textFieldValue = try {
@@ -276,7 +278,7 @@ fun NumberSliderRow(config: NumberSliderConfig, values: SnapshotStateMap<String,
       BasicTextField(
         value = textFieldValue,
         modifier = Modifier
-          .width(80.dp)
+          .width(dimensionResource(com.jahi.pipelinetest.R.dimen.text_field_width_small))
           .focusRequester(focusRequester)
           .onFocusChanged {
             isFocused = it.isFocused
@@ -294,12 +296,15 @@ fun NumberSliderRow(config: NumberSliderConfig, values: SnapshotStateMap<String,
       ) { innerTextField ->
         Box(
           modifier = Modifier.border(
-            width = if (isFocused) 2.dp else 1.dp,
+            width = if (isFocused)
+              dimensionResource(com.jahi.pipelinetest.R.dimen.border_width_focused)
+            else
+              dimensionResource(com.jahi.pipelinetest.R.dimen.border_width_default),
             color = if (isFocused) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline,
-            shape = RoundedCornerShape(4.dp)
+            shape = RoundedCornerShape(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_xsmall))
           )
         ) {
-          Box(modifier = Modifier.padding(8.dp)) {
+          Box(modifier = Modifier.padding(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small))) {
             innerTextField()
           }
         }

--- a/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/LiveCameraDialog.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/LiveCameraDialog.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -91,9 +93,13 @@ fun LiveCameraDialog(
     cameraProvider?.unbindAll()
     onDismissed((sumFps / fpsCount).toInt())
   }) {
-    Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) {
+    Card(
+      modifier = Modifier.fillMaxWidth(),
+      shape = RoundedCornerShape(dimensionResource(com.jahi.pipelinetest.R.dimen.dialog_corner_radius))
+    ) {
       Column(
-        modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = Modifier.padding(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_medium)),
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_default))
       ) {
         // Title
         Row(
@@ -101,10 +107,10 @@ fun LiveCameraDialog(
           horizontalArrangement = Arrangement.SpaceBetween,
           modifier = Modifier
             .fillMaxWidth()
-            .padding(bottom = 8.dp)
+            .padding(bottom = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small))
         ) {
           Text(
-            "Live camera",
+            stringResource(com.jahi.pipelinetest.R.string.live_camera),
             style = MaterialTheme.typography.titleLarge,
           )
           if (streamingMessage != null) {
@@ -133,7 +139,7 @@ fun LiveCameraDialog(
               contentDescription = "",
               modifier = Modifier
                 .fillMaxHeight()
-                .clip(RoundedCornerShape(8.dp)),
+                .clip(RoundedCornerShape(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small))),
               contentScale = ContentScale.Inside
             )
           }
@@ -152,7 +158,7 @@ fun LiveCameraDialog(
         Row(
           modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 8.dp),
+            .padding(top = dimensionResource(com.jahi.pipelinetest.R.dimen.padding_small)),
           horizontalArrangement = Arrangement.End,
         ) {
           TextButton(
@@ -161,7 +167,7 @@ fun LiveCameraDialog(
               onDismissed((sumFps / fpsCount).toInt())
             },
           ) {
-            Text("OK")
+            Text(stringResource(com.jahi.pipelinetest.R.string.ok))
           }
         }
       }

--- a/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/MessageInputText.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/MessageInputText.kt
@@ -98,6 +98,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -246,10 +247,10 @@ fun MessageInputText(
             text = {
               Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny))
               ) {
                 Icon(Icons.Rounded.PhotoCamera, contentDescription = "")
-                Text("Take a picture")
+                Text(stringResource(com.jahi.pipelinetest.R.string.action_take_picture))
               }
             },
             enabled = pickedImages.isEmpty() && !hasImageMessage,
@@ -277,10 +278,10 @@ fun MessageInputText(
             text = {
               Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny))
               ) {
                 Icon(Icons.Rounded.Photo, contentDescription = "")
-                Text("Pick from album")
+                Text(stringResource(com.jahi.pipelinetest.R.string.action_pick_from_album))
               }
             },
             enabled = pickedImages.isEmpty() && !hasImageMessage,
@@ -296,10 +297,10 @@ fun MessageInputText(
           DropdownMenuItem(text = {
             Row(
               verticalAlignment = Alignment.CenterVertically,
-              horizontalArrangement = Arrangement.spacedBy(6.dp)
+              horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny))
             ) {
               Icon(Icons.Rounded.PostAdd, contentDescription = "")
-              Text("Prompt templates")
+              Text(stringResource(com.jahi.pipelinetest.R.string.action_prompt_templates))
             }
           }, onClick = {
             onOpenPromptTemplatesClicked()
@@ -310,10 +311,10 @@ fun MessageInputText(
         DropdownMenuItem(text = {
           Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
+            horizontalArrangement = Arrangement.spacedBy(dimensionResource(com.jahi.pipelinetest.R.dimen.padding_tiny))
           ) {
             Icon(Icons.Rounded.History, contentDescription = "")
-            Text("Input history")
+            Text(stringResource(com.jahi.pipelinetest.R.string.action_input_history))
           }
         }, onClick = {
           showAddContentMenu = false

--- a/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/ModelNotDownloaded.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/gallery/ui/common/chat/ModelNotDownloaded.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -40,7 +41,7 @@ fun ModelNotDownloaded(modifier: Modifier = Modifier, onClicked: () -> Unit) {
     Button(
       onClick = onClicked,
     ) {
-      Text("Download & Try it", maxLines = 1)
+      Text(stringResource(com.jahi.pipelinetest.R.string.download_try_it), maxLines = 1)
     }
   }
 }

--- a/app/src/main/java/com/jahi/pipelinetest/ui/components/TaskList.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/ui/components/TaskList.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.jahi.pipelinetest.R
 import com.jahi.pipelinetest.model.Task
@@ -64,28 +65,32 @@ fun TaskList(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp),
+                    .padding(bottom = dimensionResource(R.dimen.padding_small)),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "Tasks ($completedTasks/$totalTasks)",
+                    text = stringResource(
+                        R.string.tasks_progress,
+                        completedTasks,
+                        totalTasks
+                    ),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )
                 LinearProgressIndicator(
                     progress = if (totalTasks > 0) completedTasks.toFloat() / totalTasks else 0f,
                     modifier = Modifier
-                        .width(100.dp)
-                        .height(8.dp)
+                        .width(dimensionResource(R.dimen.task_progress_width))
+                        .height(dimensionResource(R.dimen.task_progress_height))
                 )
             }
         } else {
             Text(
-                text = "Tasks",
+                text = stringResource(R.string.title_tasks),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_small))
             )
         }
 
@@ -93,13 +98,13 @@ fun TaskList(
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp),
+                    .padding(bottom = dimensionResource(R.dimen.padding_small)),
                 colors = CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.surfaceVariant
                 )
             ) {
                 Column(
-                    modifier = Modifier.padding(12.dp)
+                    modifier = Modifier.padding(dimensionResource(R.dimen.padding_regular))
                 ) {
                     OutlinedTextField(
                         value = newDescription,
@@ -135,7 +140,7 @@ fun TaskList(
                         readOnly = true,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp),
+                            .padding(top = dimensionResource(R.dimen.padding_small)),
                         interactionSource = interactionSource,
                         trailingIcon = {
                             Row {
@@ -160,7 +165,7 @@ fun TaskList(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp),
+                            .padding(top = dimensionResource(R.dimen.padding_small)),
                         horizontalArrangement = Arrangement.End
                     ) {
                         TextButton(onClick = {
@@ -191,10 +196,10 @@ fun TaskList(
                 onClick = { isAdding = true },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp)
+                    .padding(bottom = dimensionResource(R.dimen.padding_small))
             ) {
                 Icon(Icons.Default.Add, contentDescription = stringResource(R.string.task_add))
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(dimensionResource(R.dimen.padding_small)))
                 Text(stringResource(R.string.task_add))
             }
         }
@@ -219,7 +224,7 @@ fun TaskList(
                     onToggleCompletion = { taskViewModel.toggleTaskCompletion(task) },
                     onDelete = { taskViewModel.deleteTask(task) },
                     onUpdate = { updated -> taskViewModel.updateTask(updated) },
-                    modifier = Modifier.padding(vertical = 2.dp)
+                    modifier = Modifier.padding(vertical = dimensionResource(R.dimen.padding_xxsmall))
                 )
             }
         }
@@ -238,7 +243,7 @@ fun TaskItem(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 2.dp),
+            .padding(vertical = dimensionResource(R.dimen.padding_xxsmall)),
         colors = CardDefaults.cardColors(
             containerColor = if (task.isCompleted)
                 MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
@@ -253,7 +258,7 @@ fun TaskItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
+                .padding(dimensionResource(R.dimen.padding_regular)),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Checkbox(
@@ -265,7 +270,7 @@ fun TaskItem(
                 Column(
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 8.dp)
+                        .padding(horizontal = dimensionResource(R.dimen.padding_small))
                 ) {
                     OutlinedTextField(
                         value = editText,
@@ -273,7 +278,7 @@ fun TaskItem(
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(dimensionResource(R.dimen.padding_small)))
                     val displayEditDate = editDueDate.takeIf { it.isNotBlank() }?.let {
                         try {
                             val dateTime = LocalDateTime.parse(it)
@@ -355,7 +360,7 @@ fun TaskItem(
                     text = task.description,
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 8.dp),
+                        .padding(horizontal = dimensionResource(R.dimen.padding_small)),
                     textDecoration = if (task.isCompleted) TextDecoration.LineThrough else null,
                     color = if (task.isCompleted)
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
@@ -373,7 +378,7 @@ fun TaskItem(
                         text = displayDate,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(end = 8.dp)
+                        modifier = Modifier.padding(end = dimensionResource(R.dimen.padding_small))
                     )
                 }
                 IconButton(

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -28,6 +28,18 @@
     <dimen name="dialog_corner_radius">16dp</dimen>
     <dimen name="padding_medium">20dp</dimen>
     <dimen name="padding_tiny">6dp</dimen>
+    <dimen name="padding_xxsmall">2dp</dimen>
+    <dimen name="padding_regular">12dp</dimen>
+    <dimen name="task_progress_width">100dp</dimen>
+    <dimen name="task_progress_height">8dp</dimen>
+    <dimen name="icon_size_small">18dp</dimen>
+    <dimen name="padding_chat_extra_large">48dp</dimen>
+    <dimen name="padding_chat_large">24dp</dimen>
+    <dimen name="padding_chat_medium">12dp</dimen>
+    <dimen name="slider_height_small">24dp</dimen>
+    <dimen name="text_field_width_small">80dp</dimen>
+    <dimen name="border_width_default">1dp</dimen>
+    <dimen name="border_width_focused">2dp</dimen>
 
     <!-- Chat screen dimensions -->
     <dimen name="chat_message_max_width">280dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,15 @@
     <string name="year_countdown">Year Countdown</string>
     <string name="tap_to_manage_tasks">Tap to manage tasks</string>
     <string name="tasks_progress">Tasks: %1$d/%2$d</string>
+    <string name="title_tasks">Tasks</string>
+    <string name="text_copied">Text copied to clipboard</string>
+    <string name="copy_text">Copy text</string>
+    <string name="action_take_picture">Take a picture</string>
+    <string name="action_pick_from_album">Pick from album</string>
+    <string name="action_prompt_templates">Prompt templates</string>
+    <string name="action_input_history">Input history</string>
+    <string name="download_try_it">Download &amp; Try it</string>
+    <string name="live_camera">Live camera</string>
 
     <!-- Life Screen -->
     <string name="life_hourglass">Life Hourglass</string>

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -23,6 +23,16 @@
    - Updated Compose code to use `stringResource()` and `dimensionResource()`.
    - Build verified with `./gradlew assembleDebug --offline`.
 
+## Recent Changes (June 7, 2025)
+
+### Completed Today
+1. **Replaced Remaining Hardcoded Constants**:
+   - Moved strings and dp values from `TaskList` and gallery chat components into resources.
+   - Added new dimensions (`padding_xxsmall`, `padding_regular`, `task_progress_width`, `task_progress_height`, `icon_size_small`, `padding_chat_*`, `slider_height_small`, `text_field_width_small`, `border_width_*`).
+   - Added new strings (`title_tasks`, `text_copied`, `copy_text`, `action_take_picture`, `action_pick_from_album`, `action_prompt_templates`, `action_input_history`, `download_try_it`, `live_camera`).
+   - Updated Compose files to use resource references.
+   - Build verified with `./gradlew assembleDebug --offline`.
+
 ## Recent Changes (June 4, 2025)
 
 ### Completed Today

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -94,7 +94,7 @@
 - ⏳ **Migrate to Timber logging** (replace existing Log.d calls)
 - ⏳ Add analytics
 - ⏳ Performance optimizations
-- ⏳ Remove remaining hardcoded strings and dimensions
+- ✅ Removed remaining hardcoded strings and dimensions for TaskList and gallery chat components
 
 ## Known Issues 🐛
 


### PR DESCRIPTION
## Summary
- store remaining chat and task strings in resources
- move dp values to dimens and reference with `dimensionResource`
- update gallery chat components and TaskList to use resources
- document progress in memory bank

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_6843373af854832aa57aab36b1e0b2fe