### PR TITLE
Adjust tasks tab text color

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -161,8 +161,8 @@ class MainActivity : ComponentActivity() {
                                     colors = NavigationBarItemDefaults.colors(
                                         selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
                                         selectedTextColor = com.jahi.pipelinetest.ui.theme.Slate100,
-                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate400,
-                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate200,
+                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate200,
                                         indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
                                     )
                                 )

--- a/app/src/main/java/com/jahi/pipelinetest/ui/theme/Color.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/ui/theme/Color.kt
@@ -7,6 +7,7 @@ val Slate900 = Color(0xFF1A202C)
 val Slate800 = Color(0xFF2D3748)
 val Slate700 = Color(0xFF4A5568)
 val Slate100 = Color(0xFFF1F5F9)
+val Slate200 = Color(0xFFE2E8F0)
 val Slate400 = Color(0xFF94A3B8)
 
 // Accent colors

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -33,6 +33,14 @@
    - Updated Compose files to use resource references.
    - Build verified with `./gradlew assembleDebug --offline`.
 
+## Recent Changes (June 8, 2025)
+
+### Completed Today
+1. **Improved Tasks Tab Readability**:
+   - Added new `Slate200` color in theme.
+   - Tasks tab now uses this lighter gray instead of black.
+   - Build verified with `./gradlew assembleDebug --offline`.
+
 ## Recent Changes (June 4, 2025)
 
 ### Completed Today

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -86,6 +86,7 @@
 - ⏳ Bulk task operations
 - ⏳ Search functionality
 - ⏳ Export/import tasks
+- ✅ Tasks tab text color lightened for readability
 
 ### Technical Debt
 - ⏳ Update deprecated APIs


### PR DESCRIPTION
## Summary
- add Slate200 color constant
- use Slate200 for unselected Tasks navigation item
- note color change in Progress and Active Context

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_684371e380f0832ab5a0fbc5bf097075