### PR TITLE
Revert last commit and adjust tasks tab text color

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -148,8 +148,8 @@ class MainActivity : ComponentActivity() {
                                     colors = NavigationBarItemDefaults.colors(
                                         selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
                                         selectedTextColor = com.jahi.pipelinetest.ui.theme.Slate100,
-                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate400,
-                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate200,
+                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate200,
                                         indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
                                     )
                                 )


### PR DESCRIPTION
## Summary
- revert merge PR that tweaked tasks tab color
- add `Slate200` gray to theme
- lighten tasks tab label color using `Slate200`
- document the change in Memory Bank

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_68438031386c832a9475026661a18a51