### PR TITLE
Revert tasks tab color change

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/MainActivity.kt
@@ -161,8 +161,8 @@ class MainActivity : ComponentActivity() {
                                     colors = NavigationBarItemDefaults.colors(
                                         selectedIconColor = com.jahi.pipelinetest.ui.theme.Slate100,
                                         selectedTextColor = com.jahi.pipelinetest.ui.theme.Slate100,
-                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate200,
-                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate200,
+                                        unselectedIconColor = com.jahi.pipelinetest.ui.theme.Slate400,
+                                        unselectedTextColor = com.jahi.pipelinetest.ui.theme.Slate400,
                                         indicatorColor = com.jahi.pipelinetest.ui.theme.Indigo600
                                     )
                                 )

--- a/app/src/main/java/com/jahi/pipelinetest/ui/theme/Color.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/ui/theme/Color.kt
@@ -7,7 +7,6 @@ val Slate900 = Color(0xFF1A202C)
 val Slate800 = Color(0xFF2D3748)
 val Slate700 = Color(0xFF4A5568)
 val Slate100 = Color(0xFFF1F5F9)
-val Slate200 = Color(0xFFE2E8F0)
 val Slate400 = Color(0xFF94A3B8)
 
 // Accent colors

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -32,14 +32,15 @@
    - Added new strings (`title_tasks`, `text_copied`, `copy_text`, `action_take_picture`, `action_pick_from_album`, `action_prompt_templates`, `action_input_history`, `download_try_it`, `live_camera`).
    - Updated Compose files to use resource references.
    - Build verified with `./gradlew assembleDebug --offline`.
-
 ## Recent Changes (June 8, 2025)
 
 ### Completed Today
-1. **Improved Tasks Tab Readability**:
-   - Added new `Slate200` color in theme.
-   - Tasks tab now uses this lighter gray instead of black.
+1. **Reverted tasks tab color change**:
+   - Reverted merge commit that lightened tasks tab text color.
+   - Removed Slate200 color constant.
+   - Tasks tab uses Slate400 again.
    - Build verified with `./gradlew assembleDebug --offline`.
+
 
 ## Recent Changes (June 4, 2025)
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -86,7 +86,7 @@
 - ⏳ Bulk task operations
 - ⏳ Search functionality
 - ⏳ Export/import tasks
-- ✅ Tasks tab text color lightened for readability
+- ⏳ Lighten tasks tab text color for readability
 
 ### Technical Debt
 - ⏳ Update deprecated APIs


### PR DESCRIPTION
## Summary
- revert merge commit that lightened the Tasks tab text color
- document the revert in the memory bank

## Testing
- `./gradlew assembleDebug --offline`


------
https://chatgpt.com/codex/tasks/task_b_6843e7a43bd0832aa569539983c9e3b7