### PR TITLE
Set white color for event names

### DIFF
--- a/app/src/main/java/com/jahi/pipelinetest/TaskOverviewScreen.kt
+++ b/app/src/main/java/com/jahi/pipelinetest/TaskOverviewScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import com.jahi.pipelinetest.ui.components.TaskList
 import com.jahi.pipelinetest.viewmodel.TaskViewModel
@@ -30,6 +31,7 @@ fun TaskOverviewScreen(
                 Text(
                     text = event.name,
                     style = MaterialTheme.typography.titleMedium,
+                    color = colorResource(R.color.white),
                     modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_small))
                 )
             }

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -40,6 +40,9 @@
    - Removed Slate200 color constant.
    - Tasks tab uses Slate400 again.
    - Build verified with `./gradlew assembleDebug --offline`.
+2. **Event name text color set to white**:
+   - TaskOverviewScreen now displays event names using white color for better contrast.
+   - Build verified with `./gradlew assembleDebug --offline`.
 
 
 ## Recent Changes (June 4, 2025)

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -87,6 +87,7 @@
 - ⏳ Search functionality
 - ⏳ Export/import tasks
 - ⏳ Lighten tasks tab text color for readability
+- ✅ Event names displayed in white for better readability
 
 ### Technical Debt
 - ⏳ Update deprecated APIs


### PR DESCRIPTION
## Summary
- show event names with white text in TaskOverviewScreen
- document event name color change in Active Context and Progress

## Testing
- `./gradlew assembleDebug --offline`

------
https://chatgpt.com/codex/tasks/task_b_68442533074c832a8644509a52acdd36